### PR TITLE
In Cascade Assets `ContentTypes::ModularController`, move logic for `spike` action into `one_column` and remove `spike` route.

### DIFF
--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -44,7 +44,7 @@ module ContentTypes
         'PAGE WRAPPER OPEN' => '',
 
         # TODO: convert these to cascade_format action. There are action items.
-        'PRIMARY CONTENT' => render_static_primary_content,
+        'PRIMARY CONTENT' => render_static_ad_landing_primary_content,
         'FOOTER' => render_static_partial('widgets/ad_landing_page/sponsor_bar')
       }
 
@@ -54,38 +54,43 @@ module ContentTypes
 
     # GET /modular/one_column
     # Maps to Content Types/Modular/1 Column in Cascade.
+    # rubocop:disable Metrics/MethodLength
     def one_column
       @configuration_set = ConfigurationSet.one_column
-      @metadata_set = MetadataSet.page(title: 'Modular ContentType Spike')
-
-      # TODO: Model DataDefinition.
-      @dd = nil
+      @metadata_set = MetadataSet.page(title: 'Modular One Column')
+      @data_definition = DataDefinitions::OneColumn.default
 
       # Define configuration set regions. This mimics the regions section of Configuation Set
       # properties view in Cascade.
       @configuration_set.regions = {
-        # TODO: clean these up!
-        'JQUERY' => cascade_block('_cascade/blocks/html/jquery'),
-
-        # We can just set the paths statically because we turned off assets digest and debug in
-        # config/environments/development.rb and are building assets on fly in before_action.
+        'ADDITIONAL BODY AT-END' => '',
+        'ADDITIONAL HEAD' => '',
         'CASCADE ASSETS' => cascade_block('_cascade/blocks/html/cascade_assets'),
+        'FB_JS_SDK' => cascade_block('_cascade/blocks/html/facebook_javascript_sdk'),
+        'GOOGLE_ANALYTICS' => '',
+        'JQUERY' => cascade_block('_cascade/blocks/html/jquery'),
+        'JUMP LINK' => cascade_block('_cascade/blocks/html/jump_link'),
+        'META VIEWPORT' => cascade_block('_cascade/blocks/html/global_meta_viewport'),
+        'NAVIGATION' => '',
+        'OG_TAGS' => '',
+        'PAGE WRAPPER CLOSE' => '',
+        'PAGE WRAPPER OPEN' => '',
 
-        'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),
-        'NAVIGATION' => render_static_partial('widgets/shared/navigation'),
-        'MASTHEAD' => render_velocity('_cascade/formats/modular/one_column_masthead', @dd),
-        'PRIMARY CONTENT' => '<h2>Welcome to the Spike!</h2>',
+        # TODO: convert these to cascade_format action.
+        'MASTHEAD' => render_static_partial('widgets/shared/header'),
+        'PRIMARY CONTENT' => '<h2>PRIMARY CONTENT GOES HERE!</h2>',
         'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
       }
 
       render @configuration_set.template
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 
     # rubocop:disable Metrics/MethodLength
     # TODO: Replace with more Cascadesque rendering.
-    def render_static_primary_content
+    def render_static_ad_landing_primary_content
       # This reproduces content from static sample version.
       primary_content = <<-HTML
 <div id="column-container" class="ad-landing-column-container">

--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -17,41 +17,6 @@ module ContentTypes
     before_action :build_assets_on_fly
     after_action :render_region_tags, :render_system_page_meta_tags
 
-    # TODO: Move this to one_column method and remove this method. There is an Action Item.
-    # GET /modular/spike
-    def spike
-      @configuration_set = ConfigurationSet.one_column
-      @metadata_set = MetadataSet.page(title: 'Modular ContentType Spike')
-
-      # TODO: Model DataDefinition.
-      @dd = nil
-
-      # Define configuration set regions. This mimics the regions section of Configuation Set
-      # properties view in Cascade.
-      @configuration_set.regions = {
-        # TODO: clean these up!
-        'JQUERY' => cascade_block('_cascade/blocks/html/jquery'),
-
-        # We can just set the paths statically because we turned off assets digest and debug in
-        # config/environments/development.rb and are building assets on fly in before_action.
-        'CASCADE ASSETS' => cascade_block('_cascade/blocks/html/cascade_assets'),
-
-        'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),
-        'NAVIGATION' => render_static_partial('widgets/shared/navigation'),
-        'MASTHEAD' => render_velocity('_cascade/formats/modular/one_column_masthead', @dd),
-        'PRIMARY CONTENT' => '<h2>Welcome to the Spike!</h2>',
-        'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
-      }
-
-      render @configuration_set.template
-    end
-
-    # GET /modular/one_column
-    # Maps to Content Types/Modular/1 Column in Cascade.
-    def one_column
-      render plain: 'TODO'
-    end
-
     # GET /modular/ad_landing
     # Maps to Content Types/Modular/Ad Landing in Cascade.
     # rubocop:disable Metrics/MethodLength
@@ -86,6 +51,35 @@ module ContentTypes
       render @configuration_set.template
     end
     # rubocop:enable Metrics/MethodLength
+
+    # GET /modular/one_column
+    # Maps to Content Types/Modular/1 Column in Cascade.
+    def one_column
+      @configuration_set = ConfigurationSet.one_column
+      @metadata_set = MetadataSet.page(title: 'Modular ContentType Spike')
+
+      # TODO: Model DataDefinition.
+      @dd = nil
+
+      # Define configuration set regions. This mimics the regions section of Configuation Set
+      # properties view in Cascade.
+      @configuration_set.regions = {
+        # TODO: clean these up!
+        'JQUERY' => cascade_block('_cascade/blocks/html/jquery'),
+
+        # We can just set the paths statically because we turned off assets digest and debug in
+        # config/environments/development.rb and are building assets on fly in before_action.
+        'CASCADE ASSETS' => cascade_block('_cascade/blocks/html/cascade_assets'),
+
+        'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),
+        'NAVIGATION' => render_static_partial('widgets/shared/navigation'),
+        'MASTHEAD' => render_velocity('_cascade/formats/modular/one_column_masthead', @dd),
+        'PRIMARY CONTENT' => '<h2>Welcome to the Spike!</h2>',
+        'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
+      }
+
+      render @configuration_set.template
+    end
 
     private
 

--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -70,6 +70,7 @@ module ContentTypes
         'GOOGLE_ANALYTICS' => '',
         'JQUERY' => cascade_block('_cascade/blocks/html/jquery'),
         'JUMP LINK' => cascade_block('_cascade/blocks/html/jump_link'),
+        'MASTHEAD' => cascade_format('_cascade/formats/modular/one_column_masthead'),
         'META VIEWPORT' => cascade_block('_cascade/blocks/html/global_meta_viewport'),
         'NAVIGATION' => '',
         'OG_TAGS' => '',
@@ -77,7 +78,6 @@ module ContentTypes
         'PAGE WRAPPER OPEN' => '',
 
         # TODO: convert these to cascade_format action.
-        'MASTHEAD' => render_static_partial('widgets/shared/header'),
         'PRIMARY CONTENT' => '<h2>PRIMARY CONTENT GOES HERE!</h2>',
         'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
       }
@@ -123,7 +123,8 @@ HTML
     end
 
     def cascade_format(format_path)
-      render_to_string(partial: format_path, locals: {ad_landing: @data_definition})
+      # Make data definition a local within partial as variable current_page
+      render_to_string(partial: format_path, locals: {current_page: @data_definition})
     end
 
     def render_velocity(format_path, data)

--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -27,7 +27,8 @@ module ContentTypes
       @metadata_set = MetadataSet.page(title: 'Ad Landing Page')
       @data_definition = DataDefinitions::AdLanding.default
 
-      # Define configuration set regions.
+      # Define configuration set regions. This mimics the regions section of Configuation Set
+      # properties view in Cascade.
       @configuration_set.regions = {
         'ADDITIONAL BODY AT-END' => '',
         'ADDITIONAL HEAD' => '',
@@ -60,8 +61,7 @@ module ContentTypes
       @metadata_set = MetadataSet.page(title: 'Modular One Column')
       @data_definition = DataDefinitions::OneColumn.default
 
-      # Define configuration set regions. This mimics the regions section of Configuation Set
-      # properties view in Cascade.
+      # Define configuration set regions.
       @configuration_set.regions = {
         'ADDITIONAL BODY AT-END' => '',
         'ADDITIONAL HEAD' => '',
@@ -72,12 +72,13 @@ module ContentTypes
         'JUMP LINK' => cascade_block('_cascade/blocks/html/jump_link'),
         'MASTHEAD' => cascade_format('_cascade/formats/modular/one_column_masthead'),
         'META VIEWPORT' => cascade_block('_cascade/blocks/html/global_meta_viewport'),
-        'NAVIGATION' => '',
         'OG_TAGS' => '',
         'PAGE WRAPPER CLOSE' => '',
         'PAGE WRAPPER OPEN' => '',
 
         # TODO: convert these to cascade_format action.
+        'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),
+        'NAVIGATION' => render_static_partial('widgets/shared/navigation'),
         'PRIMARY CONTENT' => '<h2>PRIMARY CONTENT GOES HERE!</h2>',
         'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
       }

--- a/app/data_definitions/ad_landing.rb
+++ b/app/data_definitions/ad_landing.rb
@@ -37,13 +37,7 @@ module DataDefinitions
     # Class Methods
     def self.default
       ad_landing = DataDefinitions::AdLanding.new
-
-      DataDefinitions::AdLanding::DEFAULTS.each do |xpath, value|
-        node = ad_landing.document.at_xpath(xpath)
-        raise "Node at xpath #{xpath} not found." unless node
-        node.content = value
-      end
-
+      ad_landing.set_defaults
       ad_landing
     end
   end

--- a/app/data_definitions/base.rb
+++ b/app/data_definitions/base.rb
@@ -1,9 +1,10 @@
 module DataDefinitions
   class Base
-    attr_accessor :document
+    attr_accessor :name, :document
 
     def initialize
-      xml_file = format('%s.xml', self.class.name.underscore.split('/').last)
+      @name = self.class.name.underscore.split('/').last
+      xml_file = format('%s.xml', @name)
       xml_path = File.join(Rails.root, 'app/data_definitions/from_cascade', xml_file)
       @document = Nokogiri::XML(File.read(xml_path)) if File.exist?(xml_path)
     end
@@ -16,15 +17,19 @@ module DataDefinitions
       end
     end
 
-    # rubocop:disable Rails/OutputSafety
-    def get_child_value(field, unescaped=false)
-      # Mirrors $element.getChild('foo').value used in Cascade Velocity formats
+    def get_child(field)
       xpath = self.class::XPATH[field]
       raise "There is no xpath set for field #{field}." unless xpath
 
       node = document.at_xpath(xpath)
       raise "Node at xpath #{xpath} not found." unless node
 
+      node
+    end
+
+    # rubocop:disable Rails/OutputSafety
+    def get_child_value(field, unescaped=false)
+      node = get_child(field)
       value = node.content
       unescaped ? value.html_safe : value
     end

--- a/app/data_definitions/base.rb
+++ b/app/data_definitions/base.rb
@@ -8,6 +8,14 @@ module DataDefinitions
       @document = Nokogiri::XML(File.read(xml_path)) if File.exist?(xml_path)
     end
 
+    def set_defaults
+      self.class::DEFAULTS.each do |xpath, value|
+        node = @document.at_xpath(xpath)
+        raise "Node at xpath #{xpath} not found." unless node
+        node.content = value
+      end
+    end
+
     # rubocop:disable Rails/OutputSafety
     def get_child_value(field, unescaped=false)
       # Mirrors $element.getChild('foo').value used in Cascade Velocity formats

--- a/app/data_definitions/from_cascade/one_column.xml
+++ b/app/data_definitions/from_cascade/one_column.xml
@@ -1,0 +1,548 @@
+<system-data-structure>
+    <group identifier="masthead" label="Masthead" collapsed="true">
+        <text type="dropdown" identifier="mastheadType" label="Type of Masthead" default="None" help-text="Choose which masthead you would like on your page.">
+            <dropdown-item value="None"/>
+            <dropdown-item value="Side panel hero" show-fields="masthead/sidePanelHero"/>
+        </text>
+        <group identifier="sidePanelHero" label="Side panel hero">
+            <group identifier="panel" label="Panel" collapsed="true">
+                <text identifier="title" label="Title"/>
+                <text identifier="subtitle" label="Subtitle"/>
+                <text wysiwyg="true" identifier="body" label="Content"/>
+                <group identifier="callsToAction" label="Calls to Action" collapsed="true">
+                    <group identifier="button" label="Button" multiple="true" maximum-number="3" minimum-number="0">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="masthead/sidePanelHero/panel/callsToAction/button/internalLink"/>
+                            <radio-item value="External Link" show-fields="masthead/sidePanelHero/panel/callsToAction/button/externalLink"/>
+                            <radio-item value="File Link" show-fields="masthead/sidePanelHero/panel/callsToAction/button/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="dropdownNav" label="Dropdown Navigation" collapsed="true">
+                    <text identifier="dropdownLabel" label="Label"/>
+                    <group identifier="dropdownLink" label="Link" multiple="true">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="masthead/sidePanelHero/panel/dropdownNav/dropdownLink/internalLink"/>
+                            <radio-item value="External Link" show-fields="masthead/sidePanelHero/panel/dropdownNav/dropdownLink/externalLink"/>
+                            <radio-item value="File Link" show-fields="masthead/sidePanelHero/panel/dropdownNav/dropdownLink/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+            </group>
+            <group identifier="featuredContent" label="Featured Content" multiple="true" collapsed="true">
+                <group identifier="featuredBackgroundMedia" label="Featured Background Media" collapsed="true">
+                    <text type="radiobutton" identifier="type" label="Type" default="Image">
+                        <radio-item value="Image" show-fields="masthead/sidePanelHero/featuredContent/featuredBackgroundMedia/imageFile, masthead/sidePanelHero/featuredContent/featuredBackgroundMedia/alignY"/>
+                        <radio-item value="Video" show-fields="masthead/sidePanelHero/featuredContent/featuredBackgroundMedia/videoFile, masthead/sidePanelHero/featuredContent/featuredBackgroundMedia/fallbackImageFile"/>
+                    </text>
+                    <asset type="file" identifier="videoFile" label="Video File"/>
+                    <asset type="file" identifier="fallbackImageFile" label="Fallback Image File (Around 1600px by 1200px)"/>
+                    <asset type="file" identifier="imageFile" label="Image File (Around 1600px by 1200px)"/>
+                    <text type="radiobutton" identifier="alignY" label="Image Align" default="Bottom">
+                        <radio-item value="Top"/>
+                        <radio-item value="Center"/>
+                        <radio-item value="Bottom"/>
+                    </text>
+                    <text identifier="alternateText" label="Alternate Text"/>
+                </group>
+                <group identifier="featuredPanel" label="Featured Panel" collapsed="true">
+                    <text identifier="category" label="Category"/>
+                    <text identifier="title" label="Title"/>
+                    <text identifier="subtitle" label="Subtitle"/>
+                    <text wysiwyg="true" identifier="body" label="Content"/>
+                    <group identifier="link" label="Call to Action">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="masthead/sidePanelHero/featuredContent/featuredPanel/link/internalLink"/>
+                            <radio-item value="External Link" show-fields="masthead/sidePanelHero/featuredContent/featuredPanel/link/externalLink"/>
+                            <radio-item value="File Link" show-fields="masthead/sidePanelHero/featuredContent/featuredPanel/link/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+            </group>
+        </group>
+    </group>
+    <group identifier="primaryContent" label="Primary Content" collapsed="true">
+        <group identifier="widget" label="Widget" multiple="true">
+            <text type="dropdown" identifier="widgetType" label="Type of Widget" default="(select a widget)" help-text="Choose the type of content you'd like to add to the page">
+                <dropdown-item value="(select a widget)"/>
+                <dropdown-item value="Text Only" show-fields="primaryContent/widget/textOnly"/>
+                <dropdown-item value="Image with Text" show-fields="primaryContent/widget/imageWithText"/>
+                <dropdown-item value="Video with Text" show-fields="primaryContent/widget/videoWithText"/>
+                <dropdown-item value="Fact Cards with Text" show-fields="primaryContent/widget/factCardsWithText"/>
+                <dropdown-item value="Call To Action 3 Up" show-fields="primaryContent/widget/callToAction3Up"/>
+                <dropdown-item value="Social.chapman Feed" show-fields="primaryContent/widget/chapmanSocialFeed"/>
+                <dropdown-item value="Subscribe" show-fields="primaryContent/widget/subscribe"/>
+                <dropdown-item value="Call To Action Block" show-fields="primaryContent/widget/callToActionBlock"/>
+                <dropdown-item value="Events.chapman Feed" show-fields="primaryContent/widget/chapmanEventsFeed"/>
+                <dropdown-item value="Stories Feed" show-fields="primaryContent/widget/chapmanStoriesFeed"/>
+                <dropdown-item value="Contact Footer" show-fields="primaryContent/widget/contactFooter"/>
+                <dropdown-item value="Call To Action Footer" show-fields="primaryContent/widget/callToActionFooter"/>
+            </text>
+            <group identifier="chapmanEventsFeed" label="Events.chapman Feed" collapsed="true">
+                <text type="radiobutton" identifier="show" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="category" label="Category"/>
+                <text identifier="title" label="Title"/>
+                <text wysiwyg="true" identifier="body" label="Content"/>
+                <text identifier="buttonText" label="Button Text"/>
+                <text identifier="featuredFeedUrl" label="Featured Event Url" required="true"/>
+                <text identifier="feedUrl" label="Feed Url" required="true"/>
+            </group>
+            <group identifier="callToActionBlock" label="Call To Action Block" collapsed="true">
+                <text type="radiobutton" identifier="display-call-to-action-block" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <group identifier="callToActionBlockRow" label="Call To Action Block Row" multiple="true" collapsed="true">
+                    <group identifier="callToActionBox" label="Call To Action Box" multiple="true" maximum-number="4" minimum-number="4" collapsed="true">
+                        <text identifier="title" label="Title"/>
+                        <text identifier="subtitle" label="Subtitle"/>
+                        <text type="radiobutton" identifier="colorTheme" label="Color Theme" default="Dark">
+                            <radio-item value="Dark"/>
+                            <radio-item value="Light"/>
+                            <radio-item value="School Color"/>
+                        </text>
+                        <group identifier="link" label="Link" collapsed="true">
+                            <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                                <radio-item value="Internal Link" show-fields="primaryContent/widget/callToActionBlock/callToActionBlockRow/callToActionBox/link/internalLink"/>
+                                <radio-item value="External Link" show-fields="primaryContent/widget/callToActionBlock/callToActionBlockRow/callToActionBox/link/externalLink"/>
+                                <radio-item value="File Link" show-fields="primaryContent/widget/callToActionBlock/callToActionBlockRow/callToActionBox/link/fileLink"/>
+                            </text>
+                            <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                            <asset type="page" identifier="internalLink" label="Internal Link"/>
+                            <asset type="file" identifier="fileLink" label="File Link"/>
+                        </group>
+                        <group identifier="media" label="Media" collapsed="true">
+                            <text type="radiobutton" identifier="linkType" label="Link Type" default="None" help-text="Photo size: around 600px width and 272 px height  (Does not need to be exact, just close)">
+                                <radio-item value="None"/>
+                                <radio-item value="File Link" show-fields="primaryContent/widget/callToActionBlock/callToActionBlockRow/callToActionBox/media/fileLink"/>
+                            </text>
+                            <asset type="file" identifier="fileLink" label="File Link (Around 600px by 272px)"/>
+                        </group>
+                    </group>
+                </group>
+            </group>
+            <group identifier="textOnly" label="Text Only" collapsed="true">
+                <text type="radiobutton" identifier="display-text-only" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="dropdown" identifier="format" label="Text Position" default="Centered" help-text="Choose how to layout your text">
+                    <dropdown-item value="Centered"/>
+                    <dropdown-item value="Off to the side" show-fields="primaryContent/widget/textOnly/textFields/textAlign"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <group identifier="textFields" label="Text Fields" collapsed="true">
+                    <text type="radiobutton" identifier="textAlign" label="Text Align" default="Left">
+                        <radio-item value="Left"/>
+                        <radio-item value="Right"/>
+                    </text>
+                    <text identifier="category" label="Category"/>
+                    <text identifier="title" label="Title"/>
+                    <text wysiwyg="true" identifier="body" label="Content"/>
+                    <group identifier="button" label="Button">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/textOnly/textFields/button/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/textOnly/textFields/button/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/textOnly/textFields/button/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="backgroundImage" label="Background Image" collapsed="true">
+                    <asset type="file" identifier="fileLink" label="File Link (Around 1600px by 800px)"/>
+                    <text identifier="alternateText" label="Alternate Text"/>
+                </group>
+            </group>
+            <group identifier="imageWithText" label="Image with Text" collapsed="true">
+                <text type="radiobutton" identifier="display-image-with-text" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="dropdown" identifier="format" label="Text and Image Positions" default="Side by side" help-text="Choose how to layout your data">
+                    <dropdown-item value="Stacked"/>
+                    <dropdown-item value="Side by side" show-fields="primaryContent/widget/imageWithText/textFields/textAlign"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <group identifier="backgroundImage" label="Background Image" collapsed="true">
+                    <text type="radiobutton" identifier="linkType" label="Link Type" default="None">
+                        <radio-item value="None"/>
+                        <radio-item value="File Link" show-fields="primaryContent/widget/imageWithText/backgroundImage/fileLink"/>
+                    </text>
+                    <asset type="file" identifier="fileLink" label="File Link"/>
+                </group>
+                <group identifier="textFields" label="Text Fields" collapsed="true">
+                    <text type="radiobutton" identifier="textAlign" label="Text Align" default="Left">
+                        <radio-item value="Left"/>
+                        <radio-item value="Right"/>
+                    </text>
+                    <text identifier="category" label="Category"/>
+                    <text identifier="title" label="Title"/>
+                    <text wysiwyg="true" identifier="body" label="Content"/>
+                    <group identifier="button" label="Button">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/imageWithText/textFields/button/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/imageWithText/textFields/button/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/imageWithText/textFields/button/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="imageFields" label="Image Fields" collapsed="true">
+                    <asset type="file" identifier="fileLink" label="File Link (Around 600px by 400px)"/>
+                    <text identifier="alternateText" label="Alternate Text"/>
+                </group>
+            </group>
+            <group identifier="videoWithText" label="Video with Text" collapsed="true">
+                <text type="radiobutton" identifier="display-video-with-text" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="dropdown" identifier="format" label="Text and Video Positions" default="Side by side" help-text="Choose how to layout your data">
+                    <dropdown-item value="Stacked"/>
+                    <dropdown-item value="Side by side" show-fields="primaryContent/widget/videoWithText/textFields/textAlign"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="youtubeShareLink" label="Youtube share link" help-text="Example: https://youtu.be/jhz862KOstA"/>
+                <group identifier="textFields" label="Text Fields" collapsed="true">
+                    <text type="radiobutton" identifier="textAlign" label="Text Align" default="Left">
+                        <radio-item value="Left"/>
+                        <radio-item value="Right"/>
+                    </text>
+                    <text identifier="category" label="Category"/>
+                    <text identifier="title" label="Title"/>
+                    <text wysiwyg="true" identifier="body" label="Content"/>
+                    <group identifier="button" label="Button">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/videoWithText/textFields/button/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/videoWithText/textFields/button/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/videoWithText/textFields/button/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+            </group>
+            <group identifier="factCardsWithText" label="Fact Cards with Text" collapsed="true">
+                <text type="radiobutton" identifier="display-fact-cards-with-text" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="dropdown" identifier="format" label="Text and Fact Positions" default="Side by side" help-text="Choose how to layout your data">
+                    <dropdown-item value="Stacked"/>
+                    <dropdown-item value="Side by side" show-fields="primaryContent/widget/factCardsWithText/textFields/textAlign"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <group identifier="textFields" label="Text Fields" collapsed="true">
+                    <text type="radiobutton" identifier="textAlign" label="Text Align" default="Left">
+                        <radio-item value="Left"/>
+                        <radio-item value="Right"/>
+                    </text>
+                    <text identifier="category" label="Category"/>
+                    <text identifier="title" label="Title"/>
+                    <text wysiwyg="true" identifier="body" label="Content"/>
+                    <group identifier="button" label="Button">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/factCardsWithText/textFields/button/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/factCardsWithText/textFields/button/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/factCardsWithText/textFields/button/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="factCards" label="Fact Cards" collapsed="true">
+                    <group identifier="factCard" label="Fact Card" multiple="true" collapsed="true">
+                        <text identifier="backLinkLabel" label="Back Link Label" required="true"/>
+                        <text identifier="plainTextLink" label="Link"/>
+                        <asset type="page,file,symlink" identifier="link" label="Or Internal Link"/>
+                        <group identifier="frontStat" label="Front Stat" collapsed="true">
+                            <text identifier="frontStatNumber" label="Front Stat Number" help-text="4 digits max; If necessary to use bigger number, abbreviate as such: 10,000 = 10k"/>
+                            <text identifier="frontStatText1" label="Front Stat Text 1"/>
+                            <text identifier="frontStatText2" label="Front Stat Text 2"/>
+                            <text type="dropdown" identifier="frontBackgroundImage" label="Background Image">
+                                <dropdown-item value="people"/>
+                                <dropdown-item value="student"/>
+                                <dropdown-item value="chair"/>
+                                <dropdown-item value="books"/>
+                                <dropdown-item value="mortarboard"/>
+                            </text>
+                            <text type="dropdown" identifier="frontBackgroundColor" label="Background Color">
+                                <dropdown-item value="red"/>
+                                <dropdown-item value="orange"/>
+                                <dropdown-item value="green"/>
+                                <dropdown-item value="blue"/>
+                            </text>
+                        </group>
+                        <group identifier="backStat" label="Back Stat" collapsed="true">
+                            <text multi-line="true" identifier="backStat" label="Back Stat"/>
+                            <group identifier="link" label="Link">
+                                <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                                    <radio-item value="Internal Link"/>
+                                    <radio-item value="External Link"/>
+                                    <radio-item value="File Link"/>
+                                </text>
+                                <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                                <asset type="page" identifier="internalLink" label="Internal Link"/>
+                                <asset type="file" identifier="fileLink" label="File Link"/>
+                                <text identifier="label" label="Label"/>
+                            </group>
+                        </group>
+                    </group>
+                </group>
+            </group>
+            <group identifier="callToAction3Up" label="Call To Action 3 Up" collapsed="true">
+                <text type="radiobutton" identifier="display-call-to-action-3-up" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <group identifier="cta1" label="Call to Action Left">
+                    <group identifier="media" label="Media">
+                        <asset type="file" identifier="fileLink" label="File Link (Exactly 600px by 400px)"/>
+                        <text identifier="alternateText" label="Alternate Text"/>
+                    </group>
+                    <group identifier="textFields" label="Text Fields">
+                        <text identifier="title" label="Title"/>
+                        <text wysiwyg="true" identifier="body" label="Content"/>
+                    </group>
+                    <group identifier="link" label="Link">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/callToAction3Up/cta1/link/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/callToAction3Up/cta1/link/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/callToAction3Up/cta1/link/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="cta2" label="Call to Action Center">
+                    <group identifier="media" label="Media">
+                        <asset type="file" identifier="fileLink" label="File Link (Exactly 600px by 400px)" help-text="Photo size: exactly 600px width and 400px height"/>
+                        <text identifier="alternateText" label="Alternate Text"/>
+                    </group>
+                    <group identifier="textFields" label="Text Fields">
+                        <text identifier="title" label="Title"/>
+                        <text wysiwyg="true" identifier="body" label="Content"/>
+                    </group>
+                    <group identifier="link" label="Link">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/callToAction3Up/cta2/link/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/callToAction3Up/cta2/link/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/callToAction3Up/cta2/link/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+                <group identifier="cta3" label="Call to Action Right">
+                    <group identifier="media" label="Media">
+                        <asset type="file" identifier="fileLink" label="File Link (Exactly 600px by 400px)" help-text="Photo size: exactly 600px width and 400px height"/>
+                        <text identifier="alternateText" label="Alternate Text"/>
+                    </group>
+                    <group identifier="textFields" label="Text Fields">
+                        <text identifier="title" label="Title"/>
+                        <text wysiwyg="true" identifier="body" label="Content"/>
+                    </group>
+                    <group identifier="link" label="Link">
+                        <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                            <radio-item value="Internal Link" show-fields="primaryContent/widget/callToAction3Up/cta3/link/internalLink"/>
+                            <radio-item value="External Link" show-fields="primaryContent/widget/callToAction3Up/cta3/link/externalLink"/>
+                            <radio-item value="File Link" show-fields="primaryContent/widget/callToAction3Up/cta3/link/fileLink"/>
+                        </text>
+                        <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                        <asset type="page" identifier="internalLink" label="Internal Link"/>
+                        <asset type="file" identifier="fileLink" label="File Link"/>
+                        <text identifier="label" label="Label"/>
+                    </group>
+                </group>
+            </group>
+            <group identifier="chapmanSocialFeed" label="Social.chapman Feed" collapsed="true">
+                <text type="radiobutton" identifier="displayChapmanSocialFeed" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="title" label="Title"/>
+                <group identifier="social-media-link" label="Social Media Link" multiple="true" collapsed="true">
+                    <text type="dropdown" identifier="social-media-type" label="Social Media Type">
+                        <dropdown-item value="Facebook"/>
+                        <dropdown-item value="GooglePlus"/>
+                        <dropdown-item value="iTunes U"/>
+                        <dropdown-item value="Instagram"/>
+                        <dropdown-item value="LinkedIn"/>
+                        <dropdown-item value="Pinterest"/>
+                        <dropdown-item value="Twitter"/>
+                        <dropdown-item value="YouTube"/>
+                    </text>
+                    <text identifier="link" label="Link"/>
+                </group>
+                <group identifier="socialFeedSettings" label="Social Feed Settings" collapsed="true">
+                    <text identifier="feedLink" label="Feed Link" regular-expression="/^(f|ht)tps?:\/\//"/>
+                    <text identifier="numberOfPosts" label="Number of Posts" regular-expression="/^\d+$/"/>
+                </group>
+            </group>
+            <group identifier="chapmanStoriesFeed" label="Stories Feed" collapsed="true">
+                <text type="radiobutton" identifier="displayChapmanStoriesFeed" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="title" label="Title"/>
+                <text identifier="feedUrl" label="Feed Url" help-text="Paste url of a blog site from blogs.chapman"/>
+                <text identifier="topStory" label="Top Story Url" help-text="Paste url of a blog post from blogs.chapman"/>
+                <group identifier="button" label="Button" collapsed="true">
+                    <text identifier="text" label="Text"/>
+                    <text identifier="link" label="Link" help-text="full url (including http)"/>
+                </group>
+            </group>
+            <group identifier="subscribe" label="Campaign Monitor Newsletter Subscribe" collapsed="true">
+                <text type="radiobutton" identifier="display-subscribe" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Dark">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="subscribeMessage" label="Subscribe Message"/>
+                <text multi-line="true" identifier="campaignMonitorHtml" label="Campaign Monitor HTML" help-text="Paste in HTML from Campaign Monitor" rows="15" cols="50"/>
+            </group>
+            <group identifier="callToActionFooter" label="Call to Action Footer" collapsed="true">
+                <text type="radiobutton" identifier="displayCallToActionFooter" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="White">
+                    <radio-item value="White"/>
+                    <radio-item value="School Color"/>
+                </text>
+                <text identifier="title" label="Title"/>
+                <group identifier="button" label="Button" multiple="true" maximum-number="3" minimum-number="0">
+                    <text type="radiobutton" identifier="linkType" label="Link Type" default="Internal Link">
+                        <radio-item value="Internal Link" show-fields="primaryContent/widget/callToActionFooter/button/linkType/internalLink"/>
+                        <radio-item value="External Link" show-fields="primaryContent/widget/callToActionFooter/button/linkType/externalLink"/>
+                        <radio-item value="File Link" show-fields="primaryContent/widget/callToActionFooter/button/linkType/fileLink"/>
+                    </text>
+                    <text identifier="externalLink" label="External Link" help-text="full url (including http) to page outside of Cascade"/>
+                    <asset type="page" identifier="internalLink" label="Internal Link"/>
+                    <asset type="file" identifier="fileLink" label="File Link"/>
+                    <text identifier="label" label="Label"/>
+                </group>
+            </group>
+            <group identifier="contactFooter" label="Contact Footer" collapsed="true">
+                <text type="radiobutton" identifier="displayContactFooter" label="Show" default="Yes">
+                    <radio-item value="Yes"/>
+                    <radio-item value="No"/>
+                </text>
+                <text type="radiobutton" identifier="bgColor" label="Background Color" default="Light">
+                    <radio-item value="Light"/>
+                    <radio-item value="Medium"/>
+                    <radio-item value="Dark"/>
+                </text>
+                <text identifier="phone" label="Phone"/>
+                <text identifier="email" label="Email"/>
+                <group identifier="address" label="Address" collapsed="true">
+                    <text identifier="name" label="Name"/>
+                    <text identifier="address-line-1" label="Address Line 1"/>
+                    <text identifier="city" label="City"/>
+                    <text identifier="state" label="State"/>
+                    <text identifier="zip" label="Zip"/>
+                </group>
+                <group identifier="social-media" label="Social Media" collapsed="true">
+                    <text identifier="title" label="Title"/>
+                    <group identifier="social-media-link" label="Social Media Link" multiple="true" collapsed="true">
+                        <text type="dropdown" identifier="social-media-type" label="Social Media Type">
+                            <dropdown-item value="Facebook"/>
+                            <dropdown-item value="GooglePlus"/>
+                            <dropdown-item value="iTunes U"/>
+                            <dropdown-item value="Instagram"/>
+                            <dropdown-item value="LinkedIn"/>
+                            <dropdown-item value="Pinterest"/>
+                            <dropdown-item value="Twitter"/>
+                            <dropdown-item value="WordPress"/>
+                            <dropdown-item value="YouTube"/>
+                        </text>
+                        <text identifier="link" label="Link"/>
+                    </group>
+                </group>
+            </group>
+        </group>
+    </group>
+    <group identifier="meta" label="Supplemental Content" collapsed="true">
+        <group identifier="sharing" label="Sharing " collapsed="true">
+            <asset type="file" identifier="og_image" label="OG Image" help-text="Image used for sharing on facebook (130px w, 110px h exactly)"/>
+            <text identifier="og_title" label="OG Title" help-text="Overrides title for when page is shared to facebook (defaults to Display Name)"/>
+            <text identifier="og_description" label="OG Description" help-text="Overrides description when page is shared to facebook"/>
+            <text identifier="twitter_text" label="Twitter Share Text" help-text="The text that prepopulates on twitter (followed by URL and hashtags)"/>
+            <text identifier="twitter_hashtag" label="Twitter Hashtag" multiple="true" maximum-number="3" help-text="Hashtags to get appended to tweet (no #!)"/>
+        </group>
+    </group>
+</system-data-structure>

--- a/app/data_definitions/one_column.rb
+++ b/app/data_definitions/one_column.rb
@@ -3,12 +3,12 @@ module DataDefinitions
     # rubocop:disable Metrics/LineLength
     # XML XPath Selectors
     XPATH = {
-      # TODO: See AdLanding DataDefinition
+      masthead_type: '//group[@identifier="masthead"]/text[@identifier="mastheadType"]'
     }.freeze
 
     # Preset Data Values
     DEFAULTS = {
-      # TODO: See AdLanding DataDefinition
+      XPATH[:masthead_type] => 'Side panel hero'
     }.freeze
     # rubocop:enable Metrics/LineLength
 

--- a/app/data_definitions/one_column.rb
+++ b/app/data_definitions/one_column.rb
@@ -1,6 +1,5 @@
 module DataDefinitions
   class OneColumn < DataDefinitions::Base
-    # rubocop:disable Metrics/LineLength
     # XML XPath Selectors
     XPATH = {
       masthead_type: '//group[@identifier="masthead"]/text[@identifier="mastheadType"]'
@@ -10,7 +9,6 @@ module DataDefinitions
     DEFAULTS = {
       XPATH[:masthead_type] => 'Side panel hero'
     }.freeze
-    # rubocop:enable Metrics/LineLength
 
     # Class Methods
     def self.default

--- a/app/data_definitions/one_column.rb
+++ b/app/data_definitions/one_column.rb
@@ -1,0 +1,22 @@
+module DataDefinitions
+  class OneColumn < DataDefinitions::Base
+    # rubocop:disable Metrics/LineLength
+    # XML XPath Selectors
+    XPATH = {
+      # TODO: See AdLanding DataDefinition
+    }.freeze
+
+    # Preset Data Values
+    DEFAULTS = {
+      # TODO: See AdLanding DataDefinition
+    }.freeze
+    # rubocop:enable Metrics/LineLength
+
+    # Class Methods
+    def self.default
+      one_column = DataDefinitions::OneColumn.new
+      one_column.set_defaults
+      one_column
+    end
+  end
+end

--- a/app/models/configuration_set.rb
+++ b/app/models/configuration_set.rb
@@ -15,19 +15,19 @@ class ConfigurationSet < Tableless
 
   validates :template, presence: true
 
+  def self.ad_landing(options={})
+    configuration_set = ConfigurationSet.new(name: 'Ad Landing')
+    configuration_set.set_defaults
+    configuration_set.template = options.fetch(:template,
+                                               '_cascade/templates/modular/ad_landing.html')
+    configuration_set
+  end
+
   def self.one_column(options={})
     configuration_set = ConfigurationSet.new(name: '1 Column')
     configuration_set.set_defaults
     configuration_set.template = options.fetch(:template,
                                                '_cascade/templates/modular/one_column.html')
-    configuration_set
-  end
-
-  def self.ad_landing(options={})
-    configuration_set = ConfigurationSet.new(name: '1 Column')
-    configuration_set.set_defaults
-    configuration_set.template = options.fetch(:template,
-                                               '_cascade/templates/modular/ad_landing.html')
     configuration_set
   end
 

--- a/app/views/_cascade/formats/modular/_one_column_masthead.erb
+++ b/app/views/_cascade/formats/modular/_one_column_masthead.erb
@@ -1,0 +1,10 @@
+<% # These import statements below don't do anything. They just mirror what's in Cascade. %>
+<% #import( "/_cascade/formats/helpers.velocity" ) %>
+<% #import( "/_cascade/formats/modular/mastheads/side_panel_hero" ) %>
+
+<% mastheadType = current_page.get_child_value(:masthead_type) %>
+
+<% if mastheadType == 'Side panel hero' %>
+  <% #outputSidePanelHero($masthead.getChild('sidePanelHero')) %>
+  <%= render "/_cascade/formats/modular/mastheads/side_panel_hero" %>
+<% end %>

--- a/app/views/_cascade/formats/modular/ad_landing/widgets/_masthead_hero.html.erb
+++ b/app/views/_cascade/formats/modular/ad_landing/widgets/_masthead_hero.html.erb
@@ -39,13 +39,13 @@
       -->
       <div class="masthead-header">
         <img class="header-mobile"
-             src="<%= ad_landing.get_child_value(:mobile_logo_src) %>"
-             alt="<%= ad_landing.get_child_value(:mobile_logo_alt) %>"/>
+             src="<%= current_page.get_child_value(:mobile_logo_src) %>"
+             alt="<%= current_page.get_child_value(:mobile_logo_alt) %>"/>
         <div class="header-desktop">
           <img class="header-logo-desktop"
-               src="<%= ad_landing.get_child_value(:desktop_logo_src) %>"
-               alt="<%= ad_landing.get_child_value(:desktop_logo_alt) %>"/>
-          <p class="header-text-desktop"><%= ad_landing.get_child_value(:header_text, true) %></p>
+               src="<%= current_page.get_child_value(:desktop_logo_src) %>"
+               alt="<%= current_page.get_child_value(:desktop_logo_alt) %>"/>
+          <p class="header-text-desktop"><%= current_page.get_child_value(:header_text, true) %></p>
         </div>
       </div>
 
@@ -65,13 +65,13 @@
       -->
       <div class="masthead-hero">
         <div class="background-image"
-             style="background-image: url('<%= ad_landing.get_child_value(:background_image) %>');">
+             style="background-image: url('<%= current_page.get_child_value(:background_image) %>');">
           <div class="outer-background-overlay"></div>
-          <article style="background-image: url('<%= ad_landing.get_child_value(:background_image) %>');">
+          <article style="background-image: url('<%= current_page.get_child_value(:background_image) %>');">
             <div class="inner-background-overlay"></div>
             <div class="content">
-              <h1 class="title"><%= ad_landing.get_child_value(:hero_title) %></h1>
-              <h2 class="subtitle"><%= ad_landing.get_child_value(:hero_subtitle) %></h2>
+              <h1 class="title"><%= current_page.get_child_value(:hero_title) %></h1>
+              <h2 class="subtitle"><%= current_page.get_child_value(:hero_subtitle) %></h2>
             </div>
           </article>
         </div>
@@ -82,17 +82,17 @@
           <!-- CASCADE
           <h2>$_EscapeTool.xml($formTitle)</h2>
           -->
-          <h2><%= ad_landing.get_child_value(:form_title) %></h2>
+          <h2><%= current_page.get_child_value(:form_title) %></h2>
 
           <div class="calls-to-action">
-            <div id="form_<%= ad_landing.get_child_value(:form_id) %>">Loading...</div>
+            <div id="form_<%= current_page.get_child_value(:form_id) %>">Loading...</div>
             <script>/*<![CDATA[*/
               var script = document.createElement('script');
               script.async = 1;
               script.src = 'https://go.chapman.edu/register/' +
-                           '?id=<%= ad_landing.get_child_value(:form_id) %>&' +
+                           '?id=<%= current_page.get_child_value(:form_id) %>&' +
                            'output=embed&' +
-                           'div=form_<%= ad_landing.get_child_value(:form_id) %>' +
+                           'div=form_<%= current_page.get_child_value(:form_id) %>' +
                            ((location.search.length > 1) ? '&' + location.search.substring(1) : '');
               var s = document.getElementsByTagName('script')[0];
               s.parentNode.insertBefore(script, s);

--- a/app/views/_cascade/formats/modular/mastheads/_side_panel_hero.erb
+++ b/app/views/_cascade/formats/modular/mastheads/_side_panel_hero.erb
@@ -1,0 +1,104 @@
+<div class="side-panel-hero">
+  <div class="hero-content">
+    <section class="hero-content-panel">
+      <h1>Dodge College of Film and Media Arts</h1>
+      <h2>Preparing students for a creative life in fiml and media arts.</h2>
+      <p>
+        Welcome to Dodge College of film and Media arts, a state-of-the-art facility open to you 24/7, acomplished faculty with a combined filmography of more than 300 feature films, a hands-on learning environment, international travel oportunities, one-of-a-kind internships, a solid alumni network and synergy across all programs.
+        Welcome to Dodge College of film and Media arts, a state-of-the-art facility open to you 24/7, acomplished faculty with a combined filmography of more than 300 feature films, a hands-on learning environment, international travel oportunities, one-of-a-kind internships, a solid alumni network and synergy across all programs.
+      </p>
+
+
+      <nav class="calls-to-action">
+        <a href="#" class="theme-bg-color theme-button">Visit Dodge</a>
+        <a href="#" class="theme-bg-color theme-button">Admission Information</a>
+      </nav>
+
+      <nav id="program-select-links" class="program-select">
+        <span class="select-arrow theme-border-color"></span>
+
+        <button class="hero-select-button theme-border-color">Sample Text</button>
+        <ul class="hero-select-list">
+          <li>
+            <a href="http://www.google.com">Programs and Majors</a>
+          </li>
+          <li><a href="http://www.google.com">Film Production</a></li>
+        </ul>
+      </nav>
+    </section>
+  </div>
+
+  <div class="cd-hero">
+    <div class="cd-arrow-left"><a href="#">&lsaquo;</a></div>
+    <div class="cd-arrow-right"><a href="#">&rsaquo;</a></div>
+    <div class="cd-slide-container">
+      <ul class="cd-hero-slider autoplay">
+        <li class="selected">
+          <div class="theme-bg-color slider-bottom-border"></div>
+          <div class="background-image" style="background-image: url('http://www.chapman.edu/dodge/_files/dmac/dmac-masthead.jpg'); ">
+            <article class="theme-bg-color-alpha">
+              <img src="http://www.chapman.edu/dodge/_files/dmac/dmac-masthead.jpg">
+              <div class="content">
+                <span class="category">Beyond Dodge</span>
+                <h2 class="title">New Orleans Becoming Hollywood South</h2>
+                <h3 class="subtitle">Alumni Discuss the film industry in New Orleans</h3>
+                <p class="body">
+                  What’s the first thing that comes to mind when you think of France and the arts? The Louvre? The Mona Lisa? Hiroshima, Mon Amour? It’s probably not animation. Yet the influence of French animation is also enormous, from the first animated film in history, Reynaud’s Pauvre Pierrot to Illumination Studios’ newest blockbuster, Minions. Dodge’s Digital...&nbsp;&nbsp;<a href="#">Read more on dodge</a>
+                </p>
+              </div>
+            </article>
+          </div>
+        </li>
+
+        <li>
+          <div class="theme-bg-color slider-bottom-border"></div>
+          <div class="background-video-wrapper">
+            <article class="theme-bg-color-alpha">
+              <video autoplay loop poster="http://www.chapman.edu/_files/img/hero-panels/fallback-images/football.jpg">
+                <source src="http://www.chapman.edu/_files/img/hero-panels/html5-videos/homecoming.mp4" type="video/mp4">
+              </video>
+              <div class="content">
+                <span class="category">Sports Broadcasting</span>
+                <h2 class="title">Students Cover Chapman's Homecoming Football Game</h2>
+                <h3 class="subtitle">Equitment and crew all from Chapman's own Dodge College</h3>
+                <p class="body">
+                  What’s the first thing that comes to mind when you think of France and the arts? The Louvre? The Mona Lisa? Hiroshima, Mon Amour? It’s probably not animation. Yet the influence of French animation is also enormous, from the first animated film in history, Reynaud’s Pauvre Pierrot to Illumination Studios’ newest blockbuster, Minions. Dodge’s Digital...&nbsp;&nbsp;<a href="#">Read more on dodge</a>
+                </p>
+              </div>
+            </article>
+            <video id="background-video" class="background-video" autoplay loop poster="http://www.chapman.edu/_files/img/hero-panels/fallback-images/football.jpg">
+              <source src="http://www.chapman.edu/_files/img/hero-panels/html5-videos/homecoming.mp4" type="video/mp4">
+            </video>
+          </div>
+        </li>
+
+       <li>
+          <div class="theme-bg-color slider-bottom-border"></div>
+          <div class="background-image" style="background-image: url('http://www.chapman.edu/dodge/_files/dmac/dmac-masthead.jpg'); ">
+            <article class="theme-bg-color-alpha">
+              <img src="http://www.chapman.edu/dodge/_files/dmac/dmac-masthead.jpg">
+              <div class="content">
+                <span class="category">Hello there</span>
+                <h2 class="title">This is my test panel, hope it works</h2>
+                <h3 class="subtitle">Alumni Discuss the film industry in New Orleans</h3>
+                <p class="body">
+                  What’s the first thing that comes to mind when you think of France and the arts? The Louvre? The Mona Lisa? Hiroshima, Mon Amour? It’s probably not animation. Yet the influence of French animation is also enormous, from the first animated film in history, Reynaud’s Pauvre Pierrot to Illumination Studios’ newest blockbuster, Minions. Dodge’s Digital...&nbsp;&nbsp;<a href="#">Read more on dodge</a>
+                </p>
+              </div>
+            </article>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div class="cd-slider-nav">
+      <nav>
+        <span class="cd-marker item-1"></span>
+        <ul>
+          <li class="selected"><a href="#0">1</a></li>
+          <li><a href="#0">2</a></li>
+          <li><a href="#0">3</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/_cascade/formats/modular/mastheads/_side_panel_hero.erb
+++ b/app/views/_cascade/formats/modular/mastheads/_side_panel_hero.erb
@@ -1,3 +1,6 @@
+<%# TODO: This is static right now. Update to mimic format script in Cascade:
+  # /_cascade/formats/modular/mastheads/side_panel_hero
+  #%>
 <div class="side-panel-hero">
   <div class="hero-content">
     <section class="hero-content-panel">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,6 +9,7 @@
 
 <h2>One Column Sample Pages</h2>
 <ul>
+  <li><%= link_to 'Modular Sample', "/modular/one_column" %></li>
 <% @one_column_pages.each do |page| %>
   <li><%= link_to page.titleize, "/one_column/#{page}" %></li>
 <% end %>

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -35,7 +35,8 @@ task build_omni_nav: :environment do
     prep_dist
 
     # Setup Rails asset paths for just omni-nav assets & compile them
-    Rails.application.config.assets.paths = [File.join(Rails.root, "/app/assets/javascripts"), File.join(Rails.root, "/app/assets/stylesheets")]
+    Rails.application.config.assets.paths = [File.join(Rails.root, "/app/assets/javascripts"),
+                                             File.join(Rails.root, "/app/assets/stylesheets")]
     Rails.application.config.assets.precompile -= ['master.js', 'master.css']
     Rails.application.config.assets.precompile += ['omni-nav.js', 'omni-nav.css']
 


### PR DESCRIPTION
This is an action item I worked on while waiting on product owners to review current story.

It enhances the one-column modular example in Cascade Assets and tweaks some of the patterns for mirroring Cascade behavior.