### PR TITLE
Homepage h2 subheading class fix

### DIFF
--- a/app/assets/stylesheets/widgets/home_page/hero_panel.scss
+++ b/app/assets/stylesheets/widgets/home_page/hero_panel.scss
@@ -30,7 +30,7 @@
     margin-right: 10px;
   }
   .actions {
-    margin-top: 50px;
+    margin-top: 25px;
   }
   #mastheadContent {
     position: relative;
@@ -66,7 +66,7 @@
   }
   .heading {
     margin: 0;
-    padding: 40px 0 0 0;
+    padding: 0;
     font-size: 32px;
     line-height: 32px;
     text-transform: none;
@@ -78,7 +78,7 @@
     font-size: 32px;
     line-height: 32px;
     text-transform: none;
-    font-weight: 800;
+    font-weight: 100;
   }
   .excerpt {
     margin: 20px 0;
@@ -143,7 +143,7 @@
     height: 400px;
     padding: 15px 0 150px 0;
     .actions {
-      margin-top: 50px;
+      margin-top: 25px;
     }
   }
 }
@@ -174,7 +174,7 @@
 
 @media only screen and (min-width: 480px) {
   #hero {
-    .heading, .subheading, .excerpt {
+    .heading, .subheading {
       display: block;
     }
     .heading, .subheading {
@@ -194,7 +194,15 @@
   }
 }
 
-@media only screen and (min-width: 780px) {
+@media only screen and (min-width: 768px) {
+  #hero {
+    .excerpt {
+      display: block;
+    }
+  }  
+}
+
+@media only screen and (min-width: 1024px) {
   #hero {
     .heading {
       font-size: 40px;

--- a/app/views/widgets/home_page/_hero_panel.html
+++ b/app/views/widgets/home_page/_hero_panel.html
@@ -10,12 +10,12 @@
     <div id="mastheadContent" class="maxWidth">
       <h2>
         <span class="heading  fast_transition" style="position: relative; left: 0px; opacity: 1;">California Scene Painting:</span>
-        <span class="subheading thin  fast_transition style="position: relative; left: 0px; opacity: 1;">A Narrative Revolution</span>
+        <span class="subheading thin  fast_transition" style="position: relative; left: 0px; opacity: 1;">A Narrative Revolution</span>
       </h2>
 
       <p class="excerpt fast_transition" style="position: relative; left: 0px; opacity: 1;">The once overlooked California Scene painting movement gets the recognition it deserves and a new home at the Hilbert Museum of California Art at Chapman University.</p>
 
-      <div class="actions fast_transition style="position: relative; left: 0px; opacity: 1;"">
+      <div class="actions fast_transition" style="position: relative; left: 0px; opacity: 1;">
         <!-- # Watch Video Button
              # There's some Javascript that tweaks this and was causing an issue.
              # See https://github.com/chapmanu/cascade-assets/issues/93

--- a/app/views/widgets/home_page/_hero_panel.html
+++ b/app/views/widgets/home_page/_hero_panel.html
@@ -9,13 +9,13 @@
   <section id="hero" class="dark-bg align-left" style="background-image:url('http://www.chapman.edu/_files/img/hero-panels/fallback-images/hilbert-art.jpg');">
     <div id="mastheadContent" class="maxWidth">
       <h2>
-        <span class="heading uppercase extended">California Scene Painting:</span>
-        <span class="subheading lowercase thin">A Narrative Revolution</span>
+        <span class="heading  fast_transition" style="position: relative; left: 0px; opacity: 1;">California Scene Painting:</span>
+        <span class="subheading thin  fast_transition" style="position: relative; left: 0px; opacity: 1;">A Narrative Revolution</span>
       </h2>
 
-      <p class="excerpt">The once overlooked California Scene painting movement gets the recognition it deserves and a new home at the Hilbert Museum of California Art at Chapman University.</p>
+      <p class="excerpt fast_transition" style="position: relative; left: 0px; opacity: 1;">The once overlooked California Scene painting movement gets the recognition it deserves and a new home at the Hilbert Museum of California Art at Chapman University.</p>
 
-      <div class="actions">
+      <div class="actions fast_transition style="position: relative; left: 0px; opacity: 1;"">
         <!-- # Watch Video Button
              # There's some Javascript that tweaks this and was causing an issue.
              # See https://github.com/chapmanu/cascade-assets/issues/93

--- a/app/views/widgets/home_page/_hero_panel.html
+++ b/app/views/widgets/home_page/_hero_panel.html
@@ -10,7 +10,7 @@
     <div id="mastheadContent" class="maxWidth">
       <h2>
         <span class="heading  fast_transition" style="position: relative; left: 0px; opacity: 1;">California Scene Painting:</span>
-        <span class="subheading thin  fast_transition" style="position: relative; left: 0px; opacity: 1;">A Narrative Revolution</span>
+        <span class="subheading thin  fast_transition style="position: relative; left: 0px; opacity: 1;">A Narrative Revolution</span>
       </h2>
 
       <p class="excerpt fast_transition" style="position: relative; left: 0px; opacity: 1;">The once overlooked California Scene painting movement gets the recognition it deserves and a new home at the Hilbert Museum of California Art at Chapman University.</p>


### PR DESCRIPTION
- Applied span styles on sample.
- Changed subheading weight to 100 per Ross. Removed excerpt class from 480px mobile view. Corrected media query from 780 to 768. Fixed heading padding to fit appropriate media.