### PR TITLE
[NO MERGE] Reproduce primary content block as Cascade format in one column modular template. 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
 
   def cascade_format(format_path)
     # Make data definition a local within partial as variable current_page
-    render_to_string(partial: format_path, locals: {current_page: @data_definition})
+    render_to_string(partial: format_path, locals: {current_page: @data_definition,
+                                                    contentRoot: @data_definition.document})
   end
 
   def render_velocity(format_path, data)

--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -75,11 +75,11 @@ module ContentTypes
         'OG_TAGS' => '',
         'PAGE WRAPPER CLOSE' => '',
         'PAGE WRAPPER OPEN' => '',
+        'PRIMARY CONTENT' => cascade_block('_cascade/formats/modular/one_column_primary_content'),
 
         # TODO: convert these to cascade_format action.
         'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),
         'NAVIGATION' => render_static_partial('widgets/shared/navigation'),
-        'PRIMARY CONTENT' => '<h2>PRIMARY CONTENT GOES HERE!</h2>',
         'GLOBAL FOOTER' => render_static_partial('widgets/shared/footer')
       }
 

--- a/app/controllers/content_types/modular_controller.rb
+++ b/app/controllers/content_types/modular_controller.rb
@@ -61,6 +61,17 @@ module ContentTypes
       @metadata_set = MetadataSet.page(title: 'Modular One Column')
       @data_definition = DataDefinitions::OneColumn.default
 
+      # Manually set primary content.
+      widget = @data_definition.document.at_xpath('//group[@identifier="widget"]')
+      widget.at_xpath('text[@identifier="widgetType"]').content = 'Image with Text'
+
+      # TEST
+      currentPage = Cascade::XPathTool.selectSingleNode(@data_definition.document, "//system-page[@current]")
+      systemData = currentPage.getChild('system-data-structure')
+      primaryContent = systemData.getChild('primaryContent')
+      widgets = Cascade::XPathTool.selectNodes(primaryContent, "widget")
+      p currentPage.name, systemData.name, widgets.length
+
       # Define configuration set regions.
       @configuration_set.regions = {
         'ADDITIONAL BODY AT-END' => '',
@@ -75,7 +86,7 @@ module ContentTypes
         'OG_TAGS' => '',
         'PAGE WRAPPER CLOSE' => '',
         'PAGE WRAPPER OPEN' => '',
-        'PRIMARY CONTENT' => cascade_block('_cascade/formats/modular/one_column_primary_content'),
+        'PRIMARY CONTENT' => cascade_format('_cascade/formats/modular/one_column_primary_content'),
 
         # TODO: convert these to cascade_format action.
         'OMNI-NAV' => render_static_partial('widgets/shared/omninav'),

--- a/app/data_definitions/base.rb
+++ b/app/data_definitions/base.rb
@@ -34,7 +34,22 @@ module DataDefinitions
       node.content = value
     end
 
+    def getChild(field)
+      # Special case. Cascade seems to use this as the data definition node. We already have this
+      # isolated as its own variable document.
+      return self if field == 'system-data-structure'
+
+      xpath = self.class::XPATH[field]
+      raise "There is no xpath set for field #{field}." unless xpath
+
+      node = document.at_xpath(xpath)
+      raise "Node at xpath #{xpath} not found." unless node
+
+      node
+    end
+
     def get_child(field)
+      # Legacy version. Use getChild above to be better mimic Cascade's VTL.
       xpath = self.class::XPATH[field]
       raise "There is no xpath set for field #{field}." unless xpath
 
@@ -52,6 +67,21 @@ module DataDefinitions
       node.nil? ? '' : node.content
     end
 
+    def select_single_node_value(xpath)
+      # Mirrors Cascade Velocity helper: $_XPathTool.selectSingleNode(node, xpath).value
+      # Returns string value.
+      xpath = format('//%s', xpath) unless xpath.start_with?('/')
+      node = @data_document.at_xpath(xpath)
+      node.nil? ? '' : node.content
+    end
+
+    def selectNodes(field)
+      # Mirrors Cascade Velocity helper: $_XPathTool.selectNodes(node, xpath).
+      # Returns DataDefinitions:NodeSet array.
+      xpath = format('//%s', xpath) unless xpath.start_with?('/')
+      @data_document.xpath(xpath)
+    end
+
     def select_nodes(xpath)
       # Mirrors Cascade Velocity helper: $_XPathTool.selectNodes(node, xpath).
       # Returns DataDefinitions:NodeSet array.
@@ -62,15 +92,35 @@ module DataDefinitions
 
   # Extend Nokogiri Nodeset
   module NokogiriExtensions
+    module Document
+      def getChild(identifier)
+        # system-data-structure is identifier for document root node.
+        return root if identifier == 'system-data-structure'
+
+        xpath = format('*[@identifier="%s"]', identifier)
+        at_xpath(xpath)
+      end
+    end
+
     module Element
+      def getChild(identifier)
+        xpath = format('*[@identifier="%s"]', identifier)
+        at_xpath(xpath)
+      end
+
       def select_single_node_value(xpath)
         node = at_xpath(xpath)
         raise "Node not found for xpath #{xpath}." unless node
         node.content
       end
+
+      def value
+        content
+      end
     end
   end
 
   # Monkey-patch it now!
+  Nokogiri::XML::Document.include DataDefinitions::NokogiriExtensions::Document
   Nokogiri::XML::Element.include DataDefinitions::NokogiriExtensions::Element
 end

--- a/app/data_definitions/one_column.rb
+++ b/app/data_definitions/one_column.rb
@@ -2,7 +2,10 @@ module DataDefinitions
   class OneColumn < DataDefinitions::Base
     # XML XPath Selectors
     XPATH = {
-      masthead_type: '//group[@identifier="masthead"]/text[@identifier="mastheadType"]'
+      masthead_type: '//group[@identifier="masthead"]/text[@identifier="mastheadType"]',
+      primary_widget_image_with_text: '//group[@identifier="primaryContent"]' \
+                                      '/group[@identifier="widget"]' \
+                                      '/text[@identifier="widgetType"]'
     }.freeze
 
     # Preset Data Values

--- a/app/views/_cascade/formats/modular/_one_column_primary_content.erb
+++ b/app/views/_cascade/formats/modular/_one_column_primary_content.erb
@@ -16,30 +16,28 @@ $contentRoot = contentRoot
 
 # VTL import syntax:
 #import( "/_cascade/formats/helpers.velocity" )
-
-#import( '/_cascade/formats/modular/widgets/1 Column/fact_cards_with_text' )
-#import( "/_cascade/formats/modular/widgets/1 Column/video_with_text" )
-#import( "/_cascade/formats/modular/widgets/1 Column/image_with_text" )
-#import( "/_cascade/formats/modular/widgets/1 Column/text_only" )
-#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_3_up" )
-#import( "/_cascade/formats/modular/widgets/1 Column/chapman_social_feed" )
-#import( "/_cascade/formats/modular/widgets/1 Column/subscribe" )
-#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_block" )
-#import( "/_cascade/formats/modular/widgets/1 Column/chapman_events_feed" )
-#import( "/_cascade/formats/modular/widgets/1 Column/chapman_stories_feed" )
-#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_footer" )
-#import( "/_cascade/formats/modular/widgets/1 Column/contact_footer" )
+Cascade::Velocity.import('/_cascade/formats/helpers.velocity')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/fact_cards_with_text')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/video_with_text')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/image_with_text')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/text_only')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/call_to_action_3_up')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/chapman_social_feed')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/subscribe')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/call_to_action_block')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/chapman_events_feed')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/chapman_stories_feed')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/call_to_action_footer')
+Cascade::Velocity.import('/_cascade/formats/modular/widgets/1 Column/contact_footer')
 
 # VTL set syntax:
 #set ($currentPage = $_XPathTool.selectSingleNode($contentRoot, "//system-page[@current]") )
-#set ($primaryContent = $currentPage.getChild('system-data-structure').getChild('primaryContent'))
-#set ($widgets = $_XPathTool.selectNodes($primaryContent, "widget"))
-#set ($meta = $currentPage.getChild('system-data-structure').getChild('meta') )
-
 Cascade::Velocity.set($currentPage = Cascade::XPathTool.selectSingleNode($contentRoot, "//system-page[@current]"))
 Cascade::Velocity.set($primaryContent = $currentPage.getChild('system-data-structure').getChild('primaryContent'))
 Cascade::Velocity.set($widgets = Cascade::XPathTool.selectNodes($primaryContent, "widget"))
+#Cascade::Velocity.set($meta = $currentPage.getChild('system-data-structure').getChild('meta'))
 
+# TODO: Recreate this in each loop down below.
 ## Widgets
 #foreach ($widget in $widgets)
     #set ($widgetType = $widget.getChild('widgetType').value)
@@ -100,6 +98,7 @@ Cascade::Velocity.set($widgets = Cascade::XPathTool.selectNodes($primaryContent,
   <% widgetType = widget.getChild('widgetType').value %>
 
   <% if widgetType == 'Image with Text' %>
+    <%#= Cascade::Macros.outputImageWithText(widget) %>
     <pre>outputImageWithText(widget)</pre>
   <% end %>
 

--- a/app/views/_cascade/formats/modular/_one_column_primary_content.erb
+++ b/app/views/_cascade/formats/modular/_one_column_primary_content.erb
@@ -1,0 +1,89 @@
+<%
+# This file mirrors, or parodies, the Cascade VTL script at
+# /_cascade/formats/modular/1 Column Primary Content
+#
+# It uses snakeCase variable to match those used in Cascade as closely as possible.
+#
+
+# VTL import syntax:
+#import( "/_cascade/formats/helpers.velocity" )
+
+#import( '/_cascade/formats/modular/widgets/1 Column/fact_cards_with_text' )
+#import( "/_cascade/formats/modular/widgets/1 Column/video_with_text" )
+#import( "/_cascade/formats/modular/widgets/1 Column/image_with_text" )
+#import( "/_cascade/formats/modular/widgets/1 Column/text_only" )
+#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_3_up" )
+#import( "/_cascade/formats/modular/widgets/1 Column/chapman_social_feed" )
+#import( "/_cascade/formats/modular/widgets/1 Column/subscribe" )
+#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_block" )
+#import( "/_cascade/formats/modular/widgets/1 Column/chapman_events_feed" )
+#import( "/_cascade/formats/modular/widgets/1 Column/chapman_stories_feed" )
+#import( "/_cascade/formats/modular/widgets/1 Column/call_to_action_footer" )
+#import( "/_cascade/formats/modular/widgets/1 Column/contact_footer" )
+
+# VTL set syntax:
+#set ($currentPage = $_XPathTool.selectSingleNode($contentRoot, "//system-page[@current]"))
+
+#set ($primaryContent = _xPathTool_selectSingleNode($contentRoot, '//system-page[@current]'))
+#set ($widgets = _xPathTool_selectNodes($primaryContent, 'widget'))
+#set ($widgets = $_XPathTool.selectNodes($primaryContent, "widget"))
+#set ($meta = $currentPage.getChild('system-data-structure').getChild('meta') )
+
+## Widgets
+#foreach ($widget in $widgets)
+    #set ($widgetType = $widget.getChild('widgetType').value)
+
+    #if ($widgetType == 'Fact Cards with Text')
+        #outputFactCardsWithText($widget)
+    #end
+
+    #if ($widgetType == 'Image with Text')
+        #outputImageWithText($widget)
+    #end
+
+    #if ($widgetType == 'Video with Text')
+        #outputVideoWithText($widget)
+    #end
+
+    #if ($widgetType == 'Text Only')
+        #outputTextOnly($widget)
+    #end
+
+    #if ($widgetType == 'Call To Action 3 Up')
+        #outputCallToAction3Up($widget)
+    #end
+
+    #if ($widgetType == 'Social.chapman Feed')
+        #outputChapmanSocialFeed($widget)
+    #end
+
+    #if ($widgetType == 'Subscribe')
+        #outputSubscribe($widget)
+    #end
+
+    #if ($widgetType == 'Call To Action Block')
+        #outputCallToActionBlock($widget)
+    #end
+
+    #if ($widgetType == 'Events.chapman Feed')
+        #outputChapmanEventsFeed($widget)
+    #end
+
+    #if ($widgetType == 'Stories Feed')
+        #outputChapmanStoriesFeed($widget)
+    #end
+
+    #if ($widgetType == 'Call To Action Footer')
+        #outputCallToActionFooter($widget)
+    #end
+
+    #if ($widgetType == 'Contact Footer')
+        #outputContactFooter($widget)
+    #end
+#end
+###inspectXML($widget)
+%>
+
+<%= Cascade::Velocity.output('<h3>Primary Content Here</h3>') %>
+<p>More content.</p>
+

--- a/app/views/_cascade/formats/modular/_one_column_primary_content.erb
+++ b/app/views/_cascade/formats/modular/_one_column_primary_content.erb
@@ -98,8 +98,7 @@ Cascade::Velocity.set($widgets = Cascade::XPathTool.selectNodes($primaryContent,
   <% widgetType = widget.getChild('widgetType').value %>
 
   <% if widgetType == 'Image with Text' %>
-    <%#= Cascade::Macros.outputImageWithText(widget) %>
-    <pre>outputImageWithText(widget)</pre>
+    <%= Cascade::Macros.outputImageWithText(widget) %>
   <% end %>
 
   <%= widgetType %>

--- a/app/views/_cascade/formats/modular/_one_column_primary_content.erb
+++ b/app/views/_cascade/formats/modular/_one_column_primary_content.erb
@@ -1,9 +1,18 @@
 <%
+#
 # This file mirrors, or parodies, the Cascade VTL script at
 # /_cascade/formats/modular/1 Column Primary Content
 #
 # It uses snakeCase variable to match those used in Cascade as closely as possible.
 #
+
+# In Cascade, $contentRoot is a default object in Velocity context. From docs:
+# contentRoot - JDOM Element containing the XML supplied for the current region. This content
+# could be coming from a block or the page's own structured data or xml. To view the raw XML,
+# simply apply no Format to that region.
+# contentRoot here is the data_definition object set by the ApplicationController cascade_format
+# method. It is reassigned to $contentRoot to be consistent with code in Cascade.
+$contentRoot = contentRoot
 
 # VTL import syntax:
 #import( "/_cascade/formats/helpers.velocity" )
@@ -22,12 +31,14 @@
 #import( "/_cascade/formats/modular/widgets/1 Column/contact_footer" )
 
 # VTL set syntax:
-#set ($currentPage = $_XPathTool.selectSingleNode($contentRoot, "//system-page[@current]"))
-
-#set ($primaryContent = _xPathTool_selectSingleNode($contentRoot, '//system-page[@current]'))
-#set ($widgets = _xPathTool_selectNodes($primaryContent, 'widget'))
+#set ($currentPage = $_XPathTool.selectSingleNode($contentRoot, "//system-page[@current]") )
+#set ($primaryContent = $currentPage.getChild('system-data-structure').getChild('primaryContent'))
 #set ($widgets = $_XPathTool.selectNodes($primaryContent, "widget"))
 #set ($meta = $currentPage.getChild('system-data-structure').getChild('meta') )
+
+Cascade::Velocity.set($currentPage = Cascade::XPathTool.selectSingleNode($contentRoot, "//system-page[@current]"))
+Cascade::Velocity.set($primaryContent = $currentPage.getChild('system-data-structure').getChild('primaryContent'))
+Cascade::Velocity.set($widgets = Cascade::XPathTool.selectNodes($primaryContent, "widget"))
 
 ## Widgets
 #foreach ($widget in $widgets)
@@ -84,6 +95,15 @@
 ###inspectXML($widget)
 %>
 
-<%= Cascade::Velocity.output('<h3>Primary Content Here</h3>') %>
-<p>More content.</p>
+<%# Note: you can't use global $widget as block var %>
+<% $widgets.each do | widget | %>
+  <% widgetType = widget.getChild('widgetType').value %>
 
+  <% if widgetType == 'Image with Text' %>
+    <pre>outputImageWithText(widget)</pre>
+  <% end %>
+
+  <%= widgetType %>
+<% end %>
+
+<p>More primary content.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,13 @@ module CascadeAssetsRails
     config.assets.prefix = "/_assets"
 
     # Need to include this to autoload data_definitions directory (even in Rails 4.2).
-    config.autoload_paths += %W(#{config.root}/app)
+    config.autoload_paths << Rails.root.join('app')
+
+    # Autoload lib libraries: http://stackoverflow.com/a/19650564/6763239
+    config.autoload_paths << Rails.root.join('lib')
+
+    # Auto reload code on change: http://stackoverflow.com/a/16625210/6763239
+    config.eager_load_paths << Rails.root.join('lib')
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/lib/cascade/macros.rb
+++ b/lib/cascade/macros.rb
@@ -1,0 +1,14 @@
+#
+# This class mimics, or parodies, various Velocity macros found in Cascade.
+#
+# TODO: Need to rethink this. Cascade macros function more like partials than they do helper
+# methods.
+#
+module Cascade
+  class Macros
+    # From _cascade/formats/modular/widgets/1 Column/image_with_text
+    def self.outputImageWithText(element)
+      'TODO: Need to rethink this. Macros function more like partials than they do helper methods.'
+    end
+  end
+end

--- a/lib/cascade/velocity.rb
+++ b/lib/cascade/velocity.rb
@@ -10,5 +10,11 @@ module Cascade
     def self.output(html)
         html.html_safe
     end
+
+    # This method is syntactic pap. It doesn't do anything functional except mimic the VTL set
+    # method in a view context.
+    def self.set(var)
+        var
+    end
   end
 end

--- a/lib/cascade/velocity.rb
+++ b/lib/cascade/velocity.rb
@@ -1,0 +1,14 @@
+#
+# This class mimics, or parodies, the helpers and functions provided by Velocity in
+# Cascade. Perhaps in the future, it could be replaced by a full-fledged Velocity
+# templating DSL (like Slim).
+#
+module Cascade
+  class Velocity
+    # Simple proof-of-concept method.
+    # Usage: <%= Cascade::Velocity.output('<h3>Primary Content Here</h3>') %>
+    def self.output(html)
+        html.html_safe
+    end
+  end
+end

--- a/lib/cascade/velocity.rb
+++ b/lib/cascade/velocity.rb
@@ -5,16 +5,23 @@
 #
 module Cascade
   class Velocity
+    # This method is syntactic pap. It doesn't do anything functional except mimic the VTL import
+    # method in a view context. Macros should be added to macros.rb.
+    # Usage: Cascade::Velocity.import('/_cascade/formats/helpers.velocity')
+    def self.import(path)
+        path
+    end
+
+    # More syntactic pap. It mimics the VTL set method in a view context.
+    # Usage:
+    def self.set(var)
+        var
+    end
+
     # Simple proof-of-concept method.
     # Usage: <%= Cascade::Velocity.output('<h3>Primary Content Here</h3>') %>
     def self.output(html)
         html.html_safe
-    end
-
-    # This method is syntactic pap. It doesn't do anything functional except mimic the VTL set
-    # method in a view context.
-    def self.set(var)
-        var
     end
   end
 end

--- a/lib/cascade/x_path_tool.rb
+++ b/lib/cascade/x_path_tool.rb
@@ -1,0 +1,28 @@
+#
+# This class mimics the Cascade Velocity XPathTool. See Hannon Hill docs for more information:
+# - http://www.hannonhill.com/kb/Script-Formats/
+#
+module Cascade
+  class XPathTool
+    def self.selectSingleNode(node, xpath)
+        # Mirrors Cascade Velocity helper: $_XPathTool.selectSingleNode(node, xpath).
+        # Returns Nokogiri Node element mimicking Cacade JDOM element.
+
+        # Special case which returns node, which should be the data definition XML document.
+        return node if xpath == "//system-page[@current]"
+
+        xpath = format('//%s', xpath) unless xpath.start_with?('/')
+        node.at_xpath(xpath)
+    end
+
+    def self.selectNodes(node, identifier)
+      # Mirrors Cascade Velocity helper: $_XPathTool.selectNodes(node, xpath). But only supports
+      # a single identifier at present, not an xpath because Cascade xpaths are paths of
+      # identifiers whereas Nokogiri and the rest of world expects node names.
+      # See http://www.hannonhill.com/kb/Script-Formats/#xpath-tool
+      # Returns Nokogiri NodeSet array.
+      xpath = format('*[@identifier="%s"]', identifier)
+      node.xpath(xpath)
+    end
+  end
+end


### PR DESCRIPTION
**Note: This branch is not ready to merge. If it has not been merged by 2017-06-30, I recommend it be deleted.**

The goal here is to reproduce as closely as possible the syntax and logic of the Cascade format for the primary content region in the one column modular template. That way, we could develop these scripts in Cascade Assets, put them under source control, and then move them over to Cascade with as little translation as possible.

It introduces a new `Cascade` library under `lib`.

I tried to do this by bending Rails / Ruby syntax, but it broke down once I got to Cascade Velocity macros. If you have ideas for working around this, you are welcome to take it up. I'd recommend discussing it with me first.

An alternative approach would be to build an actual interpreter for VTL, kinda  like Slim:

https://github.com/slim-template/slim

But that would be well beyond the scope of this project right now.