### PR TITLE
CDC/CES options to news/events widget AND sample snippets for Left Col Shared Content

### DIFF
--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -5,7 +5,7 @@ $(function () {
 	var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
 
 	/* Populate news from Wordpress RSS feed (converted to JSON with YQL)
-  ------------------------------------------------------------------------------------------------*/
+  	------------------------------------------------------------------------------------------------*/
 	if ($(".news").length) {
 
 		var newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings",
@@ -410,10 +410,9 @@ $(function () {
   // Show today label if appropriate
   var todayLabel = function () {
       var today = new Date(),
-          tomorrow = new Date(),
-          month = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "DEC"];
-
-      tomorrow.setDate(tomorrow.getDate() + 1);
+      	tomorrow = new Date(),
+        month = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "DEC"];
+		tomorrow.setDate(tomorrow.getDate() + 1);
 
       // Today
       $(".newsEvents .date").each(function (index) {
@@ -437,16 +436,12 @@ $(function () {
           }
       });
   };
-  // todayLabel();
 
-	$(".events .copy").each(function (index) {
-	    $(this).html($(this).text());
-	});
+  $(".events .copy").each(function (index) {
+  	$(this).html($(this).text());
+  });
 
-	$ellipsis = $(".ellipsis");
+  $ellipsis = $(".ellipsis");
   if ($ellipsis) $ellipsis.ellipsis();
-
-	// Need to add this after the ellipsis takes effect
-	// $(".newsEventsContent>li, .tabContent>li").css("display", "none");
 
 });

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -77,7 +77,12 @@ $(function () {
               $(".allNews")
                   .attr("href", "http://blogs.chapman.edu/scst");
               break;
-          case "Students":
+          case "SOC":
+              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSOC";
+              $(".allNews")
+                  .attr("href", "http://blogs.chapman.edu/communication");
+              break;
+		  case "Students":
               newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsStudents";
               $(".allNews")
                   .attr("href", "http://blogs.chapman.edu/happenings");
@@ -164,6 +169,11 @@ $(function () {
                 $(".allEvents")
                     .attr("href", "https://events.chapman.edu/?group_id=11,73,29,92,31,163,10");
                 break;
+			case "CDC":
+                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCDC";
+                $(".allEvents")
+                    .attr("href", "https://events.chapman.edu/?group_id=14");
+                break;
             case "CES":
                 eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCES";
                 $(".allEvents")
@@ -213,6 +223,11 @@ $(function () {
                 eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSCHMID";
                 $(".allEvents")
                     .attr("href", "https://events.chapman.edu/?group_id=36,101,120,22,123,129,112");
+                break;
+			case "SOC":
+                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSOC";
+                $(".allEvents")
+                    .attr("href", "https://events.chapman.edu/?group_id=146");
                 break;
             case "STUDENTS":
                 eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSTUDENTS";

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -1,333 +1,304 @@
 $(function () {
-  // Make it work with old code.
-  var pad2 = utils.pad2;
-  var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
-  var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
+	// Make it work with old code.
+	var pad2 = utils.pad2;
+	var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
+	var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
 
 	/* Populate news from Wordpress RSS feed (converted to JSON with YQL)
   ------------------------------------------------------------------------------------------------*/
-  if ($(".news").length) {
+	if ($(".news").length) {
 
-      var newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings",
+		var newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings",
 
-          newsYqlUrl = function () {
-              return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
-          },
-          newsFeedOptions = $(".newsFeed").text();
+		newsYqlUrl = function () {
+      		return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
+        },
+		newsFeedOptions = $(".newsFeed").text();
 
-      switch (newsFeedOptions) {
-          case "Admissions":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsAdmissions";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/cu-students");
-              break;
-          case "ASBE":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsBusiness";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/business");
-              break;
-          case "CES":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCES";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/ces");
-              break;
-          case "Commencement":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCommencement";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/commencement");
-              break;
-          case "COPA":
+      	switch (newsFeedOptions) {
+			case "Admissions":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsAdmissions";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/cu-students");
+				  break;
+			case "ASBE":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsBusiness";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/business");
+				  break;
+			case "CES":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCES";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/ces");
+				  break;
+			case "Commencement":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCommencement";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/commencement");
+				  break;
+			case "COPA":	
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCOPA";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/copa");
+				  break;
+			case "Crean":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCrean";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/crean");
+				  break;
+			case "Dodge":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsDodge";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/dodge");
+				  break;
+			case "Happenings":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/happenings");
+				  break;
+			case "Information Systems":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsIST";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/information-systems");
+				  break;
+			case "Law":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/law");
+				  break;
+			case "Pharmacy":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/pharmacy");
+				  break;
+			case "Schmid":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSCHMID";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/scst");
+				  break;
+			case "SOC":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSOC";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/communication");
+				  break;
+			case "Students":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsStudents";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/happenings");
+				  break;
+			case "Thompson Policy Institute":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsThompsonInstitute";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/tpi/");
+				  break;
+			case "Wilkinson":
+				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsWilkinson";
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/wilkinson");
+				  break;
+			default:
+				  $(".allNews")
+					  .attr("href", "http://blogs.chapman.edu/happenings");
+				  break;			
+		}
 
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCOPA";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/copa");
-              break;
-          case "Crean":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCrean";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/crean");
-              break;
-          case "Dodge":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsDodge";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/dodge");
-              break;
-          case "Happenings":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/happenings");
-              break;
-          case "Information Systems":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsIST";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/information-systems");
-              break;
-          case "Law":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/law");
-              break;
-          case "Pharmacy":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/pharmacy");
-              break;
-          case "Schmid":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSCHMID";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/scst");
-              break;
-          case "SOC":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSOC";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/communication");
-              break;
-		  case "Students":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsStudents";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/happenings");
-              break;
-		  case "Thompson Policy Institute":
-                newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsThompsonInstitute";
-                $(".allNews")
-                    .attr("href", "http://blogs.chapman.edu/tpi/");
-                break;
-          case "Wilkinson":
-              newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsWilkinson";
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/wilkinson");
-              break;
-          default:
-              $(".allNews")
-                  .attr("href", "http://blogs.chapman.edu/happenings");
-              break;
-      }
-
-      $(".news .loading").siblings(".story").css("visibility", "hidden");
-      $.getJSON(newsYqlUrl(), function (data) {
-          var newsData = data.query.results;
-
-          if (newsData) {
-              $(".newsEvents").each(function () {
-                  $(this).find(".news .story").each(function (i) {
-                      var $this = $(this);
-
-                      if(newsData.item[i].pubDate){
-                      //Month
-                      $this.find(".date .month").html(newsData.item[i].pubDate.split(' ')[2].toUpperCase());
-                      //Day
-                      $this.find(".date .day").html(pad2(parseInt((newsData.item[i].pubDate.split(' ')[1]), 10)));
-                      //Year
-                      $this.find(".date .year").html(newsData.item[i].pubDate.split(' ')[3]);
-                      }
-                      //Title
-                      $this.find("h3>a").html(newsData.item[i].title);
-                      //Links
-
-                      $this.find("h3>a, .readMore").each(function () {
-                          $(this).attr('href', newsData.item[i].link);
-                      });
-                      //Copy
-                      //$this.find(".copy").html($(newsData.item[i].description).text().substring(0, 175)).ellipsis();
-                      //Show today/tomorrow label if appropriate
-                      //todayLabel();                        
-
-
-                      //Show News
-                      $(".news .loading").hide().siblings(".story").css("visibility", "visible");
-                  });
-              });
-
-
-          } else {
-              $(".news").html("<p>Oops, <a href='" + newsFeedUrl + "'>" + newsFeedUrl + "</a> appears to be unresponsive or is not returning anything to display at the moment.</p>");
-          }
-
-      });
-  }
+      	$(".news .loading").siblings(".story").css("visibility", "hidden");
+      	$.getJSON(newsYqlUrl(), function (data) {
+			var newsData = data.query.results;
+			if (newsData) {
+				$(".newsEvents").each(function () {
+					$(this).find(".news .story").each(function (i) {
+						var $this = $(this);
+						if (newsData.item[i].pubDate) {
+							//Month
+							$this.find(".date .month").html(newsData.item[i].pubDate.split(' ')[2].toUpperCase());
+							//Day
+							$this.find(".date .day").html(pad2(parseInt((newsData.item[i].pubDate.split(' ')[1]), 10)));
+							//Year
+							$this.find(".date .year").html(newsData.item[i].pubDate.split(' ')[3]);
+						}
+						//Title
+						$this.find("h3>a").html(newsData.item[i].title);
+						//Links
+						$this.find("h3>a, .readMore").each(function () {
+							$(this).attr('href', newsData.item[i].link);
+						});
+ 						//Show News
+						$(".news .loading").hide().siblings(".story").css("visibility", "visible");
+					});
+				});
+          	} 
+			else {
+            	$(".news").html("<p>Oops, <a href='" + newsFeedUrl + "'>" + newsFeedUrl + "</a> appears to be unresponsive or is not returning anything to display at the moment.</p>");
+          	}
+      	});
+	}
 
   /* 
    Populate events from RSS feeds (converted to JSON with YQL)
   ------------------------------------------------------------------------------------------------ */
-  if ($(".events")
-          .length) {
-          //var eventsFeedUrl = "https://25livepub.collegenet.com/calendars/calendar.7285.rss",
+  
+	if ($(".events").length) {
+  		//sample: eventsFeedUrl = "https://25livepub.collegenet.com/calendars/calendar.7285.rss",
+		var eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events",
+        	eventsYqlUrl = function () {
+            	return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + eventsFeedUrl + "'&format=json&diagnostics=true&callback=?")
+            },
+            eventsFeedOptions = $(".eventsFeed").text();
+          	$(".allEvents").attr("href", "https://events.chapman.edu/");
+
+          	switch (eventsFeedOptions) {
+				case "ASBE":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventBusiness";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=11,73,29,92,31,163,10");
+					break;
+				case "CDC":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCDC";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=14");
+					break;
+				case "CES":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCES";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=61,20");
+					break;
+				case "COPA":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCOPA";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=21,56,105,75,89");
+					break;
+				case "CREAN":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCREAN";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=44,108,103,155,152,27,37,114,38");
+					break;
+				case "DANCE":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDANCE";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=105");
+					break;
+				case "DODGE":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDODGE";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=23");
+					break;
+				case "Information Systems":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventIST";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=133");
+					break;
+				case "LAW":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventLAW";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=28");
+					break;
+				case "MUSIC":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventMUSIC";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=56,89");
+					break;
+				case "PHARMACY":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventPHARMACY";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=141");
+					break;
+				case "SCHMID":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSCHMID";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=36,101,120,22,123,129,112");
+					break;
+				case "SOC":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSOC";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=146");
+					break;
+				case "STUDENTS":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSTUDENTS";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=53,135,58,70,137,49,99,88,131,14,144,50,126,64,74,71,102,142,41,153,116,15,94,164,19,26,34,30,114,38,117");
+					break;
+				case "THEATRE":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHEATRE";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=75");
+					break;
+				case "Thompson Policy Institute":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHOMPSONPOLICY";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=191");
+					break;
+				case "WILKINSON":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventWILKINSON";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=84,115,60,86,146,87,134,115,128,160,110,82,132,45,43,40");
+					break;
+				case "ESI":
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventESI";
+					$(".allEvents")
+						.attr("href", "https://events.chapman.edu/?group_id=83");
+					break;
+				default:
+					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events";
+					break;
+        	}
+
+			$(".events .loading").siblings(".story").css("visibility", "hidden");
+          	$.getJSON(eventsYqlUrl(), function (data) {
+            	var eventsData = data.query.results;
+              	if (eventsData) {
+                	$(".newsEvents").each(function () {
+                    	$(this).find(".events .story").each(function (i) {
+                        	var $this = $(this);
+                          	var rssitem;
+                          	var maxloop;
+                          	if (typeof eventsData.item.length == 'undefined') {
+                            	rssitem = eventsData.item;
+                            	maxloop = 0;
+							}
+                          	else {
+                            	rssitem = eventsData.item[i];
+                            	maxloop = eventsData.item.length;
+                          	}
+
+                          	if (rssitem){
+								//pubdate sometimes contained original but not current event date; use category field instead (has yyyy/mm/dd format):
+								//Month
+								//$this.find(".date .month").html(rssitem.pubDate.split(' ')[1].toUpperCase());
+								$this.find(".date .month").html(toShortMonthName_fromstring(rssitem.category.split('/')[1].toUpperCase()));
+								//Day
+								//$this.find(".date .day").html(pad2(parseInt((rssitem.pubDate.split(' ')[0]), 10)));
+								$this.find(".date .day").html(pad2(parseInt((rssitem.category.split('/')[2]), 10)));
+								//Year
+								//$this.find(".date .year").html(rssitem.pubDate.split(' ')[2]);
+								$this.find(".date .year").html(rssitem.category.split('/')[0]);
+								//Title
+								$this.find("h3>a").html(rssitem.title);
+								//Links
+								$this.find("h3>a, .readMore").each(function () {
+									$(this).attr('href', rssitem.link);
+								});
+                          	}
+                          	else{
+                            	$(this).hide();
+                          	}
+
+                          	//Show Events
+                          	$(".events .loading").hide().siblings(".story").css("visibility", "visible");
+                          	if (maxloop == i) {
+                            	return false;
+                          	}
+                      	});
+                  	});
 
 
-          var eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events",
-              eventsYqlUrl = function () {
-                  return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + eventsFeedUrl + "'&format=json&diagnostics=true&callback=?")
-              },
-              eventsFeedOptions = $(".eventsFeed")
-                  .text();
-          $(".allEvents")
-              .attr("href", "https://events.chapman.edu/");
-
-          switch (eventsFeedOptions) {
-            case "ASBE":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventBusiness";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=11,73,29,92,31,163,10");
-                break;
-			case "CDC":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCDC";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=14");
-                break;
-            case "CES":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCES";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=61,20");
-                break;
-            case "COPA":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCOPA";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=21,56,105,75,89");
-                break;
-            case "CREAN":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCREAN";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=44,108,103,155,152,27,37,114,38");
-                break;
-            case "DANCE":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDANCE";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=105");
-                break;
-            case "DODGE":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDODGE";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=23");
-                break;
-            case "Information Systems":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventIST";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=133");
-                break;
-            case "LAW":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventLAW";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=28");
-                break;
-            case "MUSIC":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventMUSIC";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=56,89");
-                break;
-            case "PHARMACY":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventPHARMACY";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=141");
-                break;
-            case "SCHMID":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSCHMID";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=36,101,120,22,123,129,112");
-                break;
-			case "SOC":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSOC";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=146");
-                break;
-            case "STUDENTS":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSTUDENTS";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=53,135,58,70,137,49,99,88,131,14,144,50,126,64,74,71,102,142,41,153,116,15,94,164,19,26,34,30,114,38,117");
-                break;
-            case "THEATRE":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHEATRE";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=75");
-                break;
-			case "Thompson Policy Institute":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHOMPSONPOLICY";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=191");
-                break;
-            case "WILKINSON":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventWILKINSON";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=84,115,60,86,146,87,134,115,128,160,110,82,132,45,43,40");
-                break;
-            case "ESI":
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventESI";
-                $(".allEvents")
-                    .attr("href", "https://events.chapman.edu/?group_id=83");
-                break;
-            default:
-                eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events";
-                break;
-        }
-
-          $(".events .loading").siblings(".story").css("visibility", "hidden");
-          $.getJSON(eventsYqlUrl(), function (data) {
-
-              var eventsData = data.query.results;
-              if (eventsData) {
-                  $(".newsEvents").each(function () {
-                      $(this).find(".events .story").each(function (i) {
-                          var $this = $(this);
-
-
-                          var rssitem;
-                          var maxloop;
-                          if (typeof eventsData.item.length == 'undefined') {
-                              rssitem = eventsData.item;
-                              maxloop = 0;
-
-
-                          } else {
-                              rssitem = eventsData.item[i];
-                              maxloop = eventsData.item.length;
-                          }
-
-                          if(rssitem){
-
-                              //pubdate sometimes contained original but not current event date; use category field instead (has yyyy/mm/dd format):
-                              //Month
-                              //$this.find(".date .month").html(rssitem.pubDate.split(' ')[1].toUpperCase());
-                              $this.find(".date .month").html(toShortMonthName_fromstring(rssitem.category.split('/')[1].toUpperCase()));
-                              //Day
-                              //$this.find(".date .day").html(pad2(parseInt((rssitem.pubDate.split(' ')[0]), 10)));
-                              $this.find(".date .day").html(pad2(parseInt((rssitem.category.split('/')[2]), 10)));
-                              //Year
-                              //$this.find(".date .year").html(rssitem.pubDate.split(' ')[2]);
-                              $this.find(".date .year").html(rssitem.category.split('/')[0]);
-                              //Title
-                              $this.find("h3>a").html(rssitem.title);
-                              //Links
-
-                              $this.find("h3>a, .readMore").each(function () {
-                                  $(this).attr('href', rssitem.link);
-                              });
-                          }
-                          else{
-                              $(this).hide();
-                          }
-
-                          //Copy
-                          //$this.find(".copy").html(rssitem.description.substring(0, 175)).ellipsis();
-                          //Show today/tomorrow label if appropritae
-                          //todayLabel();
-                          //Set href of all events link
-                          //move this into cases above and manually set for each school: $(".allEvents").attr("href", eventsFeedUrl.slice(0, -4));
-                          //Show Events
-                          $(".events .loading").hide().siblings(".story").css("visibility", "visible");
-
-                          if (maxloop == i) {
-                              return false;
-                          }
-                      });
-                  });
-
-
-              } else {
-                  $(".events").html("<p>There are no events found (or <a href='" + eventsFeedUrl + "'>" + eventsFeedUrl + "</a> is temporarily down).</p>");
-                  //$(".events").html("<p>No events found at this time.</p>");
-              }
-
-          });
-      }
+				} 
+				else {
+                	$(".events").html("<p>There are no events found (or <a href='" + eventsFeedUrl + "'>" + eventsFeedUrl + "</a> is temporarily down).</p>");
+                  	//$(".events").html("<p>No events found at this time.</p>");
+              	}
+			});
+		}
 
 	/* Switch news events tabs
   ------------------------------------------------------------------------------------------------*/

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -5,105 +5,86 @@ $(function () {
 	var toShortMonthName_fromstring = utils.toShortMonthName_fromstring;
 
 	/* Populate news from Wordpress RSS feed (converted to JSON with YQL)
-  	------------------------------------------------------------------------------------------------*/
+	------------------------------------------------------------------------------------------------*/
 	if ($(".news").length) {
-
 		var newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings",
+			newsYqlUrl = function () {
+				return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
+			},
+			newsFeedOptions = $(".newsFeed").text();
 
-		newsYqlUrl = function () {
-      		return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
-        },
-		newsFeedOptions = $(".newsFeed").text();
-
-      	switch (newsFeedOptions) {
+		switch (newsFeedOptions) {
 			case "Admissions":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsAdmissions";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/cu-students");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsAdmissions";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/cu-students");
+				break;
 			case "ASBE":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsBusiness";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/business");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsBusiness";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/business");
+				break;
 			case "CES":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCES";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/ces");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCES";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/ces");
+				break;
 			case "Commencement":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCommencement";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/commencement");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCommencement";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/commencement");
+				break;
 			case "COPA":	
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCOPA";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/copa");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCOPA";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/copa");
+				break;
 			case "Crean":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCrean";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/crean");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsCrean";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/crean");
+				break;
 			case "Dodge":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsDodge";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/dodge");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsDodge";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/dodge");
+				break;
 			case "Happenings":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/happenings");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsHappenings";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/happenings");
+				break;
 			case "Information Systems":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsIST";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/information-systems");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsIST";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/information-systems");
+				break;
 			case "Law":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/law");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/law");
+				break;
 			case "Pharmacy":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/pharmacy");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/pharmacy");
+				break;
 			case "Schmid":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSCHMID";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/scst");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSCHMID";
+				(".allNews").attr("href", "http://blogs.chapman.edu/scst");
+				break;
 			case "SOC":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSOC";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/communication");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsSOC";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/communication");
+				break;
 			case "Students":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsStudents";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/happenings");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsStudents";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/happenings");
+				break;
 			case "Thompson Policy Institute":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsThompsonInstitute";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/tpi/");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsThompsonInstitute";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/tpi/");
+				break;
 			case "Wilkinson":
-				  newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsWilkinson";
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/wilkinson");
-				  break;
+				newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsWilkinson";
+				$(".allNews").attr("href", "http://blogs.chapman.edu/wilkinson");
+				break;
 			default:
-				  $(".allNews")
-					  .attr("href", "http://blogs.chapman.edu/happenings");
-				  break;			
+				$(".allNews").attr("href", "http://blogs.chapman.edu/happenings");
+				break;			
 		}
 
-      	$(".news .loading").siblings(".story").css("visibility", "hidden");
-      	$.getJSON(newsYqlUrl(), function (data) {
+		$(".news .loading").siblings(".story").css("visibility", "hidden");
+		$.getJSON(newsYqlUrl(), function (data) {
 			var newsData = data.query.results;
 			if (newsData) {
 				$(".newsEvents").each(function () {
@@ -123,325 +104,304 @@ $(function () {
 						$this.find("h3>a, .readMore").each(function () {
 							$(this).attr('href', newsData.item[i].link);
 						});
- 						//Show News
+						//Show News
 						$(".news .loading").hide().siblings(".story").css("visibility", "visible");
 					});
 				});
-          	} 
+			} 
 			else {
-            	$(".news").html("<p>Oops, <a href='" + newsFeedUrl + "'>" + newsFeedUrl + "</a> appears to be unresponsive or is not returning anything to display at the moment.</p>");
-          	}
-      	});
+				$(".news").html("<p>Oops, <a href='" + newsFeedUrl + "'>" + newsFeedUrl + "</a> appears to be unresponsive or is not returning anything to display at the moment.</p>");
+			}
+		});
 	}
 
-  /* 
-   Populate events from RSS feeds (converted to JSON with YQL)
-  ------------------------------------------------------------------------------------------------ */
-  
+	/* Populate events from RSS feeds (converted to JSON with YQL)
+	------------------------------------------------------------------------------------------------ */
 	if ($(".events").length) {
-  		//sample: eventsFeedUrl = "https://25livepub.collegenet.com/calendars/calendar.7285.rss",
+		//sample: eventsFeedUrl = "https://25livepub.collegenet.com/calendars/calendar.7285.rss",
 		var eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events",
-        	eventsYqlUrl = function () {
-            	return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + eventsFeedUrl + "'&format=json&diagnostics=true&callback=?")
-            },
-            eventsFeedOptions = $(".eventsFeed").text();
-          	$(".allEvents").attr("href", "https://events.chapman.edu/");
+			eventsYqlUrl = function () {
+				return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + eventsFeedUrl + "'&format=json&diagnostics=true&callback=?")
+			},
+			eventsFeedOptions = $(".eventsFeed").text();
 
-          	switch (eventsFeedOptions) {
-				case "ASBE":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventBusiness";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=11,73,29,92,31,163,10");
-					break;
-				case "CDC":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCDC";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=14");
-					break;
-				case "CES":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCES";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=61,20");
-					break;
-				case "COPA":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCOPA";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=21,56,105,75,89");
-					break;
-				case "CREAN":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCREAN";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=44,108,103,155,152,27,37,114,38");
-					break;
-				case "DANCE":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDANCE";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=105");
-					break;
-				case "DODGE":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDODGE";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=23");
-					break;
-				case "Information Systems":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventIST";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=133");
-					break;
-				case "LAW":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventLAW";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=28");
-					break;
-				case "MUSIC":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventMUSIC";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=56,89");
-					break;
-				case "PHARMACY":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventPHARMACY";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=141");
-					break;
-				case "SCHMID":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSCHMID";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=36,101,120,22,123,129,112");
-					break;
-				case "SOC":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSOC";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=146");
-					break;
-				case "STUDENTS":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSTUDENTS";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=53,135,58,70,137,49,99,88,131,14,144,50,126,64,74,71,102,142,41,153,116,15,94,164,19,26,34,30,114,38,117");
-					break;
-				case "THEATRE":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHEATRE";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=75");
-					break;
-				case "Thompson Policy Institute":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHOMPSONPOLICY";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=191");
-					break;
-				case "WILKINSON":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventWILKINSON";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=84,115,60,86,146,87,134,115,128,160,110,82,132,45,43,40");
-					break;
-				case "ESI":
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventESI";
-					$(".allEvents")
-						.attr("href", "https://events.chapman.edu/?group_id=83");
-					break;
-				default:
-					eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events";
-					break;
-        	}
+		$(".allEvents").attr("href", "https://events.chapman.edu/");
 
-			$(".events .loading").siblings(".story").css("visibility", "hidden");
-          	$.getJSON(eventsYqlUrl(), function (data) {
-            	var eventsData = data.query.results;
-              	if (eventsData) {
-                	$(".newsEvents").each(function () {
-                    	$(this).find(".events .story").each(function (i) {
-                        	var $this = $(this);
-                          	var rssitem;
-                          	var maxloop;
-                          	if (typeof eventsData.item.length == 'undefined') {
-                            	rssitem = eventsData.item;
-                            	maxloop = 0;
-							}
-                          	else {
-                            	rssitem = eventsData.item[i];
-                            	maxloop = eventsData.item.length;
-                          	}
-
-                          	if (rssitem){
-								//pubdate sometimes contained original but not current event date; use category field instead (has yyyy/mm/dd format):
-								//Month
-								//$this.find(".date .month").html(rssitem.pubDate.split(' ')[1].toUpperCase());
-								$this.find(".date .month").html(toShortMonthName_fromstring(rssitem.category.split('/')[1].toUpperCase()));
-								//Day
-								//$this.find(".date .day").html(pad2(parseInt((rssitem.pubDate.split(' ')[0]), 10)));
-								$this.find(".date .day").html(pad2(parseInt((rssitem.category.split('/')[2]), 10)));
-								//Year
-								//$this.find(".date .year").html(rssitem.pubDate.split(' ')[2]);
-								$this.find(".date .year").html(rssitem.category.split('/')[0]);
-								//Title
-								$this.find("h3>a").html(rssitem.title);
-								//Links
-								$this.find("h3>a, .readMore").each(function () {
-									$(this).attr('href', rssitem.link);
-								});
-                          	}
-                          	else{
-                            	$(this).hide();
-                          	}
-
-                          	//Show Events
-                          	$(".events .loading").hide().siblings(".story").css("visibility", "visible");
-                          	if (maxloop == i) {
-                            	return false;
-                          	}
-                      	});
-                  	});
-
-
-				} 
-				else {
-                	$(".events").html("<p>There are no events found (or <a href='" + eventsFeedUrl + "'>" + eventsFeedUrl + "</a> is temporarily down).</p>");
-                  	//$(".events").html("<p>No events found at this time.</p>");
-              	}
-			});
+		switch (eventsFeedOptions) {
+			case "ASBE":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventBusiness";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=11,73,29,92,31,163,10");
+				break;
+			case "CDC":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCDC";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=14");
+				break;
+			case "CES":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCES";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=61,20");
+				break;
+			case "COPA":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCOPA";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=21,56,105,75,89");
+				break;
+			case "CREAN":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventCREAN";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=44,108,103,155,152,27,37,114,38");
+				break;
+			case "DANCE":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDANCE";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=105");
+				break;
+			case "DODGE":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventDODGE";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=23");
+				break;
+			case "Information Systems":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventIST";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=133");
+				break;
+			case "LAW":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventLAW";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=28");
+				break;
+			case "MUSIC":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventMUSIC";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=56,89");
+				break;
+			case "PHARMACY":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventPHARMACY";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=141");
+				break;
+			case "SCHMID":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSCHMID";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=36,101,120,22,123,129,112");
+				break;
+			case "SOC":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSOC";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=146");
+				break;
+			case "STUDENTS":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventSTUDENTS";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=53,135,58,70,137,49,99,88,131,14,144,50,126,64,74,71,102,142,41,153,116,15,94,164,19,26,34,30,114,38,117");
+				break;
+			case "THEATRE":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHEATRE";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=75");
+				break;
+			case "Thompson Policy Institute":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventTHOMPSONPOLICY";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=191");
+				break;
+			case "WILKINSON":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventWILKINSON";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=84,115,60,86,146,87,134,115,128,160,110,82,132,45,43,40");
+				break;
+			case "ESI":
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=eventESI";
+				$(".allEvents").attr("href", "https://events.chapman.edu/?group_id=83");
+				break;
+			default:
+				eventsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=events";
+				break;
 		}
 
+		$(".events .loading").siblings(".story").css("visibility", "hidden");
+		$.getJSON(eventsYqlUrl(), function (data) {
+			var eventsData = data.query.results;
+			if (eventsData) {
+				$(".newsEvents").each(function () {
+					$(this).find(".events .story").each(function (i) {
+						var $this = $(this);
+						var rssitem;
+						var maxloop;
+						if (typeof eventsData.item.length == 'undefined') {
+							rssitem = eventsData.item;
+							maxloop = 0;
+						}
+						else {
+							rssitem = eventsData.item[i];
+							maxloop = eventsData.item.length;
+						}
+
+						if (rssitem){
+							//pubdate sometimes contained original but not current event date; use category field instead (has yyyy/mm/dd format):
+							//Month
+							//$this.find(".date .month").html(rssitem.pubDate.split(' ')[1].toUpperCase());
+							$this.find(".date .month").html(toShortMonthName_fromstring(rssitem.category.split('/')[1].toUpperCase()));
+							//Day
+							//$this.find(".date .day").html(pad2(parseInt((rssitem.pubDate.split(' ')[0]), 10)));
+							$this.find(".date .day").html(pad2(parseInt((rssitem.category.split('/')[2]), 10)));
+							//Year
+							//$this.find(".date .year").html(rssitem.pubDate.split(' ')[2]);
+							$this.find(".date .year").html(rssitem.category.split('/')[0]);
+							//Title
+							$this.find("h3>a").html(rssitem.title);
+							//Links
+							$this.find("h3>a, .readMore").each(function () {
+								$(this).attr('href', rssitem.link);
+							});
+						}
+						else{
+							$(this).hide();
+						}
+
+						//Show Events
+						$(".events .loading").hide().siblings(".story").css("visibility", "visible");
+						if (maxloop == i) {
+							return false;
+						}
+					});
+				});
+			} 
+			else {
+				$(".events").html("<p>There are no events found (or <a href='" + eventsFeedUrl + "'>" + eventsFeedUrl + "</a> is temporarily down).</p>");
+				//$(".events").html("<p>No events found at this time.</p>");
+			}
+		});
+	}
+
 	/* Switch news events tabs
-  ------------------------------------------------------------------------------------------------*/
+	------------------------------------------------------------------------------------------------*/
 
-  $(".newsEventsNav li").click(function () {
-      var $this = $(this),
-          i = $this.index();
-      $this.addClass("active").siblings().removeClass("active");
-      $this.parent(".newsEventsNav").siblings(".newsEventsContent").children("li:eq(" + i + ")").addClass("active").siblings().removeClass("active");
-      $ellipsis = $(".ellipsis");
-      if ($ellipsis) $ellipsis.ellipsis();
-  });
+	$(".newsEventsNav li").click(function () {
+		var $this = $(this),
+		i = $this.index();
+		$this.addClass("active").siblings().removeClass("active");
+		$this.parent(".newsEventsNav").siblings(".newsEventsContent").children("li:eq(" + i + ")").addClass("active").siblings().removeClass("active");
+		$ellipsis = $(".ellipsis");
+		if ($ellipsis) $ellipsis.ellipsis();
+	});
 
-  $(".tabNav li").click(function () {
-      var $this = $(this),
-          i = $this.index();
-      $this.addClass("active").siblings().removeClass("active");
-      $this.parent(".tabNav").siblings(".tabContent").children("li:eq(" + i + ")").addClass("active").siblings().removeClass("active");
-      $ellipsis = $(".ellipsis");
-      if ($ellipsis) $ellipsis.ellipsis();
-  });
+	$(".tabNav li").click(function () {
+		var $this = $(this),
+		i = $this.index();
+		$this.addClass("active").siblings().removeClass("active");
+		$this.parent(".tabNav").siblings(".tabContent").children("li:eq(" + i + ")").addClass("active").siblings().removeClass("active");
+		$ellipsis = $(".ellipsis");
+		if ($ellipsis) $ellipsis.ellipsis();
+	});
 
-  // Apply user selected options
-  (function () {
-      var newsEventsOptions = [$(".newsEventsOptions").html(), $(".leftColumnNewsEventsOptions").html()],
-          $featureTab = [$(".main .newsEventsNav li:first-child"), $(".leftNav .newsEventsNav li:first-child")],
-          $newsTab = [$(".main .newsEventsNav li:nth-child(2)"), $(".leftNav .newsEventsNav li:nth-child(2)")],
-          $eventsTab = [$(".main .newsEventsNav li:nth-child(3)"), $(".leftNav .newsEventsNav li:nth-child(3)")],
-          $featureContent = [$(".main .featured"), $(".leftNav .featured")],
-          $newsContent = [$(".main .news"), $(".leftNav .news")],
-          $eventsContent = [$(".main .events"), $(".leftNav .events")],
-          $newsEvents = [$(".main .newsEvents"), $(".leftNav .newsEvents")];
+	// Apply user selected options
+	(function () {
+		var newsEventsOptions = [$(".newsEventsOptions").html(), $(".leftColumnNewsEventsOptions").html()],
+		$featureTab = [$(".main .newsEventsNav li:first-child"), $(".leftNav .newsEventsNav li:first-child")],
+		$newsTab = [$(".main .newsEventsNav li:nth-child(2)"), $(".leftNav .newsEventsNav li:nth-child(2)")],
+		$eventsTab = [$(".main .newsEventsNav li:nth-child(3)"), $(".leftNav .newsEventsNav li:nth-child(3)")],
+		$featureContent = [$(".main .featured"), $(".leftNav .featured")],
+		$newsContent = [$(".main .news"), $(".leftNav .news")],
+		$eventsContent = [$(".main .events"), $(".leftNav .events")],
+		$newsEvents = [$(".main .newsEvents"), $(".leftNav .newsEvents")];
 
-      for (var i = 0; i < newsEventsOptions.length; i++) {
-          switch (newsEventsOptions[i]) {
-              case "Featured - News - Events (Featured active)":
-                  break;
-              case "Featured - News - Events (News active)":
-                  $featureTab[i].removeClass("active");
-                  $newsTab[i].addClass("active");
-                  $newsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Featured - News - Events (Events active)":
-                  $featureTab[i].removeClass("active");
-                  $eventsTab[i].addClass("active");
-                  $eventsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Featured - News (Featured active)":
-                  $eventsTab[i].hide();
-                  break;
-              case "Featured - News (News active)":
-                  $featureTab[i].removeClass("active");
-                  $newsTab[i].addClass("active");
-                  $eventsTab[i].hide();
-                  $newsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Featured - Events (Featured active)":
-                  $newsTab[i].hide();
-                  break;
-              case "Featured - Events (Events active)":
-                  $featureTab[i].removeClass("active");
-                  $eventsTab[i].addClass("active");
-                  $newsTab[i].hide();
-                  $eventsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "News - Events (News active)":
-                  $featureTab[i].hide();
-                  $newsTab[i].addClass("active");
-                  $newsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "News - Events (Events active)":
-                  $featureTab[i].hide();
-                  $eventsTab[i].addClass("active");
-                  $eventsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Featured Only":
-                  $newsTab[i].hide();
-                  $eventsTab[i].hide();
-                  break;
-              case "News Only":
-                  $featureTab[i].hide();
-                  $eventsTab[i].hide();
-                  $newsTab[i].addClass("active");
-                  $newsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Events Only":
-                  $featureTab[i].hide();
-                  $newsTab[i].hide();
-                  $eventsTab[i].addClass("active");
-                  $eventsContent[i].parent("li").addClass("active");
-                  $featureContent[i].parent("li").removeClass("active");
-                  break;
-              case "Do Not Show":
-                  $newsEvents[i].hide();
-                  break;
-              default:
-                  break;
-          }
-      }
-  })();
+		for (var i = 0; i < newsEventsOptions.length; i++) {
+			switch (newsEventsOptions[i]) {
+				case "Featured - News - Events (Featured active)":
+					break;
+				case "Featured - News - Events (News active)":
+					$featureTab[i].removeClass("active");
+					$newsTab[i].addClass("active");
+					$newsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Featured - News - Events (Events active)":
+					$featureTab[i].removeClass("active");
+					$eventsTab[i].addClass("active");
+					$eventsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Featured - News (Featured active)":
+					$eventsTab[i].hide();
+					break;
+				case "Featured - News (News active)":
+					$featureTab[i].removeClass("active");
+					$newsTab[i].addClass("active");
+					$eventsTab[i].hide();
+					$newsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Featured - Events (Featured active)":
+					$newsTab[i].hide();
+					break;
+				case "Featured - Events (Events active)":
+					$featureTab[i].removeClass("active");
+					$eventsTab[i].addClass("active");
+					$newsTab[i].hide();
+					$eventsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "News - Events (News active)":
+					$featureTab[i].hide();
+					$newsTab[i].addClass("active");
+					$newsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "News - Events (Events active)":
+					$featureTab[i].hide();
+					$eventsTab[i].addClass("active");
+					$eventsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Featured Only":
+					$newsTab[i].hide();
+					$eventsTab[i].hide();
+					break;
+				case "News Only":
+					$featureTab[i].hide();
+					$eventsTab[i].hide();
+					$newsTab[i].addClass("active");
+					$newsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Events Only":
+					$featureTab[i].hide();
+					$newsTab[i].hide();
+					$eventsTab[i].addClass("active");
+					$eventsContent[i].parent("li").addClass("active");
+					$featureContent[i].parent("li").removeClass("active");
+					break;
+				case "Do Not Show":
+					$newsEvents[i].hide();
+					break;
+				default:
+					break;
+			}
+		}
+	})();
 
-  // Show today label if appropriate
-  var todayLabel = function () {
-      var today = new Date(),
-      	tomorrow = new Date(),
-        month = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "DEC"];
+	// Show today label if appropriate
+	var todayLabel = function () {
+		var today = new Date(),
+			tomorrow = new Date(),
+			month = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "DEC"];
 		tomorrow.setDate(tomorrow.getDate() + 1);
 
-      // Today
-      $(".newsEvents .date").each(function (index) {
-          if (today.getFullYear() === parseInt($(this).children(".year").html(), 10)) {
-              if (month[today.getMonth()].toUpperCase() === $(this).children(".month").html()) {
-                  if (today.getDate() === parseInt($(this).children(".day").html(), 10)) {
-                      $(this).siblings(".todayTomorrow").children(".today").css("display", "inline");
-                  }
-              }
-          }
-      });
+		// Today
+		$(".newsEvents .date").each(function (index) {
+			if (today.getFullYear() === parseInt($(this).children(".year").html(), 10)) {
+				if (month[today.getMonth()].toUpperCase() === $(this).children(".month").html()) {
+					if (today.getDate() === parseInt($(this).children(".day").html(), 10)) {
+						$(this).siblings(".todayTomorrow").children(".today").css("display", "inline");
+					}
+				}
+			}
+		});
 
-      // Tomorrow
-      $(".newsEvents .date").each(function (index) {
-          if (tomorrow.getFullYear() === parseInt($(this).children(".year").html(), 10)) {
-              if (month[tomorrow.getMonth()].toUpperCase() === $(this).children(".month").html()) {
-                  if (tomorrow.getDate() === parseInt($(this).children(".day").html(), 10)) {
-                      $(this).siblings(".todayTomorrow").children(".tomorrow").css("display", "inline");
-                  }
-              }
-          }
-      });
-  };
+		// Tomorrow
+		$(".newsEvents .date").each(function (index) {
+			if (tomorrow.getFullYear() === parseInt($(this).children(".year").html(), 10)) {
+				if (month[tomorrow.getMonth()].toUpperCase() === $(this).children(".month").html()) {
+					if (tomorrow.getDate() === parseInt($(this).children(".day").html(), 10)) {
+						$(this).siblings(".todayTomorrow").children(".tomorrow").css("display", "inline");
+					}
+				}
+			}
+		});
+	};
 
-  $(".events .copy").each(function (index) {
-  	$(this).html($(this).text());
-  });
+	$(".events .copy").each(function (index) {
+		$(this).html($(this).text());
+	});
 
-  $ellipsis = $(".ellipsis");
-  if ($ellipsis) $ellipsis.ellipsis();
+	$ellipsis = $(".ellipsis");
+	if ($ellipsis) $ellipsis.ellipsis();
 
 });

--- a/app/views/2_column/sample.html.erb
+++ b/app/views/2_column/sample.html.erb
@@ -21,7 +21,8 @@
     - primary_content/wysiwyg_anchor_links
 
   left_column:
-    - left_column/_shared_content_contacts_2.html
+    - left_column/shared_content_contacts_1.html
+    - left_column/shared_content_contacts_2.html
     - left_column/callout_1
     - left_column/callout_2
 

--- a/app/views/2_column/sample.html.erb
+++ b/app/views/2_column/sample.html.erb
@@ -21,6 +21,7 @@
     - primary_content/wysiwyg_anchor_links
 
   left_column:
+    - left_column/_shared_content_contacts_2.html
     - left_column/callout_1
     - left_column/callout_2
 

--- a/app/views/3_column/sample.html.erb
+++ b/app/views/3_column/sample.html.erb
@@ -21,7 +21,7 @@
     - primary_content/featured_news_events_feed_1
 
   left_column:
-    - left_column/_shared_content_contacts_1.html
+    - left_column/shared_content_contacts_3.html
     - left_column/callout_1
     - left_column/callout_2
     - left_column/callout_3

--- a/app/views/3_column/sample.html.erb
+++ b/app/views/3_column/sample.html.erb
@@ -21,6 +21,7 @@
     - primary_content/featured_news_events_feed_1
 
   left_column:
+    - left_column/_shared_content_contacts_1.html
     - left_column/callout_1
     - left_column/callout_2
     - left_column/callout_3

--- a/app/views/widgets/left_column/_shared_content_contacts_1.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_1.html
@@ -1,3 +1,4 @@
+<!--- this version has the optional Individual Contacts at the bottom --->
 <div class="callout-box-widget--left callout">
 	<div class="border"> </div>
     <h2>Contact Information</h2>

--- a/app/views/widgets/left_column/_shared_content_contacts_1.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_1.html
@@ -1,0 +1,56 @@
+<div class="callout-box-widget--left callout">
+	<div class="border"> </div>
+    <h2>Contact Information</h2>
+    <div class="editableContent">
+        <p>Strategic Marketing &amp; Communication</p> 
+        
+        <p>Main:
+            <br/><a href="tel:7149976661">(714) 997-6661</a>
+            <br/><a href="mailto:smc@chapman.edu">smc@chapman.edu</a>
+        </p>
+        <p>Hours:
+                <br/>8 a.m. to 5 p.m.
+        </p>
+                            
+        <h3>Location</h3>
+        
+        <p>633 West Palm
+           <br/>Suite 118A 
+           <br/>Orange, CA 92866
+        </p>
+
+        <h3>Mailing Address</h3>
+        
+        <p>Strategic Marketing &amp; Communication
+           <br/>Chapman University
+           <br/>One University Drive 
+           <br/>Orange, CA 92866
+        </p>
+
+		<h3>Individual Contact(s)</h3> 
+        <p>
+                    Esther Choi
+                    <br/>Account Manager
+                    <br/><a href="tel:7149976582">(714) 997-6582</a> 
+                    <br/><a href="mailto:echoi@chapman.edu">echoi@chapman.edu</a>                                  
+        </p>
+        <p>
+                    Drew Farrington
+                    <br/>Account Manager
+                    <br/><a href="tel:7142893142">(714) 289-3142</a> 
+                    <br/><a href="mailto:afarring@chapman.edu">afarring@chapman.edu</a>                                  
+        </p>
+        <p>
+                    Carl Minor
+                    <br/>Account Manager
+                    <br/><a href="tel:7146287214">(714) 628-7214</a> 
+                    <br/><a href="mailto:cminor@chapman.edu">cminor@chapman.edu</a>                                  
+        </p>
+        <p>
+                    Gina Madson
+                    <br/>Account Manager
+                    <br/><a href="tel:7147447961">(714) 744-7961</a> 
+                    <br/><a href="mailto:madson@chapman.edu">madson@chapman.edu</a>                                  
+        </p>
+	</div>
+</div>

--- a/app/views/widgets/left_column/_shared_content_contacts_2.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_2.html
@@ -1,0 +1,43 @@
+<div class="callout-box-widget--left callout">
+	<div class="border"> </div>
+    <h2>Contact Information</h2>
+    <div class="editableContent">
+    	<p>Information Systems &amp; Technology</p> 
+                
+        <p>Main:
+            <br/><a href="tel:7149976600">(714) 997-6600</a>
+            <br/><a href="mailto:servicedesk@chapman.edu">servicedesk@chapman.edu</a>
+        </p>
+                
+        <p>
+            Front Desk
+            <br/><a href="tel:${suppPhoneS}">714-997-6726</a> 
+            <br/><a href="mailto:"></a>  
+        </p>
+        <p>
+            Information Security
+            <br/><a href="tel:${suppPhoneS}">714-744-7972</a> 
+            <br/><a href="mailto:infoSec@chapman.edu">infoSec@chapman.edu</a>  
+        </p>
+                                                    
+                                                    <p>Hours:
+                        <br/><p>Office open for walk-in 8:00am to 12noon, 1:00pm to 5:00pm. Closed from 12noon to 1:00pm for lunch hour.</p>
+                    </p>
+                                    
+                <h3>Location</h3>
+                <p>
+                    635 W. Palm Ave.
+                                        <br/>Orange, CA 92866
+                                                               <br/><a href="https://www.chapman.edu/about/maps-directions/campus-map/index.aspx?s=subCat-a713d6dbc04d744c291bfe8353b34cb3">View Map</a>
+                                    </p>
+
+                <h3>Mailing Address</h3>
+                <p>
+                    Information Systems &amp; Technology
+                    <br/>Chapman University
+                                            <br/>One University Drive 
+                                        <br/>Orange, CA 92866
+                                    </p>
+
+                                            </div>
+    </div>

--- a/app/views/widgets/left_column/_shared_content_contacts_2.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_2.html
@@ -1,3 +1,4 @@
+<!--- this version has additional (optional) contacts after "Main" --->
 <div class="callout-box-widget--left callout">
 	<div class="border"> </div>
     <h2>Contact Information</h2>

--- a/app/views/widgets/left_column/_shared_content_contacts_3.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_3.html
@@ -1,0 +1,37 @@
+<!--- this version has the social follow us image/links at top --->
+<div class="callout-box-widget--left callout">
+	<div class="border"> </div>     
+	<h2>Contact Information</h2>
+    
+	<div id="social_follow_us">
+    	<div class="banner"></div>
+        <ul>
+            <li class="facebook first"><span class="inactive_state"></span><span class="hover_state"></span><a href="https://www.facebook.com/SchmidCollegeOfScienceTechnologyChapmanUniversity?fref=ts"><span class="hide">facebook</span></a></li>
+            <li class="blog"><span class="inactive_state"></span><span class="hover_state"></span><a href="http://blogs.chapman.edu/scst/"><span class="hide">blog</span></a></li>
+            <li class="youtube last"><span class="inactive_state"></span><span class="hover_state"></span><a href="https://www.youtube.com/watch?v=PIuSc7mOnzc&amp;list=PLBAF625333A86D39F"><span class="hide">youtube</span></a></li>    
+        </ul>
+	</div>
+                    
+    <div class="editableContent">
+        <p>Schmid College of Science &amp; Technology</p> 
+            
+        <p>Main:
+           <br/><a href="tel:7146287318">(714) 628-7318</a>
+           <br/><a href="mailto:schmidcollege@chapman.edu">schmidcollege@chapman.edu</a>
+        </p>
+        
+        <h3>Location</h3>
+        
+        <p>One University Drive
+           <br/>Orange, CA 92866
+        </p>
+
+        <h3>Mailing Address</h3>
+        
+        <p>Schmid College of Science &amp; Technology
+           <br/>Chapman University
+           <br/>One University Drive 
+           <br/>Orange, CA 92866
+        </p>
+    </div>    
+</div>


### PR DESCRIPTION
Contains an edit to the news/events javascript to include paths for CDC events feed, and CES news and events feeds.

Also has 3 new snippets of code for sample html for the Left Column Shared Content CONTACTS widget, embedded them into the Two and Three Column sample pages so Wai can work on styling them in localhost env. 