### PR TITLE
add top margin to profilePicture for faculty profile

### DIFF
--- a/app/assets/stylesheets/layout_old/faculty/profile-page.scss
+++ b/app/assets/stylesheets/layout_old/faculty/profile-page.scss
@@ -174,7 +174,7 @@
 	@include bp(m) {
 		.profilePicture {
 			position: absolute;
-			top: 50px;
+			top: 65px;
 			right: 10px;
 			float: none;
 		}


### PR DESCRIPTION
photos overlapping rank and additional titles when they are so long they
span the page, giving more top margin to photo. Issue seen on http://www.chapman.edu/our-faculty/peter-mclaren