### PR TITLE
left column shared-content Dept Contacts widget

### DIFF
--- a/app/assets/javascripts/cascade/level/shared-content-dept-contacts.js
+++ b/app/assets/javascripts/cascade/level/shared-content-dept-contacts.js
@@ -1,0 +1,9 @@
+$(function () {
+	/* button in Left Column Callout area's Contact Widget. Used to hide/show additional contact info */
+	$(".view-more-expander").click(function () {
+		//Note toggleClass removes if class exists on element and adds if missing so can list both active and hidden and will toggle one on and other off:		
+		$(this).siblings(".editableContent").toggleClass("active inactive").children(".more-content").slideToggle('slow');			
+		$(this).children(".view-more").toggleClass("active inactive").children(".view-more").slideToggle('fast');
+		$(this).children(".view-less").toggleClass("inactive active").children(".view-less").slideToggle('fast');
+	});	
+});	

--- a/app/assets/javascripts/master.js
+++ b/app/assets/javascripts/master.js
@@ -45,6 +45,7 @@
 //= require cascade/level/flickr-picasa
 //= require cascade/level/funnel
 //= require cascade/level/left-nav
+//= require cascade/level/shared-content-dept-contacts
 //= require cascade/level/level
 //= require cascade/level/masthead
 //= require cascade/level/mosaic

--- a/app/assets/stylesheets/components/icomoon.scss
+++ b/app/assets/stylesheets/components/icomoon.scss
@@ -36,7 +36,7 @@ you can use the generic selector below, but it's slower:
     -webkit-font-smoothing: antialiased;
 }
 
-.icon-menu7:before, .icon-arrow-down2:before, .icon-search:before, .icon-user3:before {
+.icon-menu7:before, .icon-arrow-down2:before, .icon-search:before, .icon-user3:before  {
     font-family: 'icomoon-ultimate';
     speak: none;
     font-style: normal;
@@ -273,7 +273,7 @@ you can use the generic selector below, but it's slower:
     content: "\e039";
 }
 
-//NEW AS OF 2/2017
+//NEW AS OF 2/2017 (ultimate)
 
 .icon-menu7:before {
     content: "\ec71";

--- a/app/assets/stylesheets/components/left-nav-sub-content.scss
+++ b/app/assets/stylesheets/components/left-nav-sub-content.scss
@@ -1,95 +1,212 @@
 .leftNavSubContent {
 	width: 100%;
-  margin: 0 0 0 0;
-  float: left;
+	margin: 0 0 0 0;
+	float: left;
 
-	//a, a:visited {
-    //border-bottom: 1px dotted #C0C0C0;
-  //}
-  .social {
-    margin: 0 0 0 25px;
-  }
+	.social {
+		margin: 0 0 0 25px;
+	}
+
 	.newsEventsNav li.active {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
+		padding-left: 20px;
+		padding-right: 20px;
+	}
+
 	.callout {
 		background-color:#d8d8d8;
 		border: 1px solid #c1c1c1;
 		vertical-align: top;
-		
 		.border {
 			height: 7px;
 			background-color: #c1c1c1;
 		}
 
-		.editableContent {
-  		a {
-  			display: inline;
-  		}
+		.contact-widget {		
+			h3, h4 {
+				margin: 5px 0;
+				font-size: 14px;
+				font-weight: 600;
+				line-height: 16px;
+			}				
+			ul.left-social-icons {
+				background-color: transparent;
+				display: block;
+				width: 100%;			
+				padding: 0;
+				margin-top: 0;
+				margin: 0 0 0 0;
+				float: left;
+				position: relative;
+				list-style: none;
+				li {
+					float: left;
+					position: relative;
+					padding-right: 12px;
+					font-size: 16px;
+					margin-bottom: 4px;
+					&.last {
+						padding-right:0;
+					}
+					a {
+						text-decoration: none;
+						border-bottom: none;
+					}
+					.icon {
+						display: inline-block;
+						color: $cu-red;
+						width: 1em;
+						height: 1em;
+						fill: currentColor;
+						padding: 0;
+					}	
 
-  		ul { 
-  			margin-top :10px;
-  		}
-
-  		.buttonLinks > li > a {
-			  display: inline-block;
+				}
 			}
+			.view-more-expander {
+				line-height: 10px;
+				text-align:center;							
+				padding: 0;
+				min-height: 35px;				
+				cursor: pointer;	
+				.active {
+					display:block;
+				}
+				.inactive {
+					display: none;
+				}
+				.view-more {
+					background-color: $cu-red;
+				}
+				.view-more-link {
+					height: 21px;
+					padding: 0 0 5px 0; 
+					margin: 0;
+					background-color: $cu-red;
+				}
+				.view-less-link {
+					height: 30px;
+					padding: 10px 0 0 0;
+					margin-bottom: -4px;
+					background-color: $cu-red;
+				}
+				a {			
+					color: $white;
+					font-size: 10px;
+					font-weight: 700;
+					letter-spacing: 1px;
+					text-transform:uppercase;
+					padding: 0;
+					&:hover  {			
+						color: $cu-warm-light-grey;
+					}
+				}
+				.icon {
+					display: inline-block;
+					color: #444444;
+					width: 1em;
+					height: 1em;
+					fill: currentColor;
+					padding: 0;
+
+				}
+				.icon-triangle-down {
+					color: #d8d8d8;
+					font-size: 18px;
+					margin-top: -4px;					
+				}
+				.icon-triangle-up {
+					color: $cu-red;
+					width:100%;
+					padding: 0;
+					font-size: 18px;
+					margin-bottom: -9px;
+				}
+			}			
+		} 	
+
+		.editableContent {	
+			.inactive {
+				display: none;
+			}	
+			.active {
+				display: block;
+			}
+			.social-follow-us {
+				margin-bottom: 65px;		
+				@include bp(l) {
+					margin-bottom: 38px;					
+				}
+
+			}
+
+			a {
+				display: inline;
+			}
+
+			ul { 
+				margin-top :10px;
+			}
+
+			.buttonLinks > li > a {
+				display: inline-block;
+			}
+			
 			.redLeftColButton {
-		    margin: 0 0 0 0;
-		    ul {
-		      list-style: none;
-		      width: 234px;
-		      margin: 0 0 0 -15px;
-		      padding: 0;
-		    }
-		    li {
-		      padding-bottom: 2px;
-		    }
-		    a {
-		      position: relative;
-		      text-align: right;
-		      padding: 0 30px 0 5px;
-		      color: $white;
-		      text-transform: uppercase;
-		      font-weight: 800;
-		      line-height: 47px;
-		      display: block;
-		      border: 1px solid #e3cfd8;
-		      background-color: #a12756;
-		      background-image: -webkit-gradient(linear, left top, left bottom, from(#a12756), to($cu-red));
-		      background-image: -webkit-linear-gradient(top, #a12756, $cu-red);
-		      background-image: -moz-linear-gradient(top, #a12756, $cu-red);
-		      background-image: -o-linear-gradient(top, #a12756, $cu-red);
-		      background-image: linear-gradient(to bottom, #a12756, $cu-red);
-		      filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#a12756', endColorstr='#{$cu-red}',GradientType=1 );
-		      font-size: 1.1em;
-		      .arrow {
-		        position: absolute;
-		        top: 50%;
-		        right: 16px;
-		        margin-top: -25px;
-		      }
-		      &:hover {
-		        background: $cu-dark-red;
-		        background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2E2ZDBkZCIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM1MDliYjIiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
-		        background: -moz-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
-		        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, $cu-dark-red), color-stop(100%, $cu-red));
-		        background: -webkit-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
-		        background: -o-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
-		        background: -ms-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
-		        background: linear-gradient(to bottom, $cu-dark-red 0%, $cu-red 100%);
-		        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$cu-dark-red}', endColorstr='#{$cu-red}',GradientType=0 );
-		      }
-		      &.long {
-		        line-height: 14px;
-		        padding: 10px 30px 10px 5px;
-		        .arrow {
-		          margin-top: -12px;
-		        }
-		      }
-		    }
-		  }
-		}
-	}
-}
+				margin: 0 0 0 0;
+				ul {
+					list-style: none;
+					width: 234px;
+					margin: 0 0 0 -15px;
+					padding: 0;
+				}
+				li {
+					padding-bottom: 2px;
+				}
+				a {
+					position: relative;
+					text-align: right;
+					padding: 0 30px 0 5px;
+					color: $white;
+					text-transform: uppercase;
+					font-weight: 800;
+					line-height: 47px;
+					display: block;
+					border: 1px solid #e3cfd8;
+					background-color: #a12756;
+					background-image: -webkit-gradient(linear, left top, left bottom, from(#a12756), to($cu-red));
+					background-image: -webkit-linear-gradient(top, #a12756, $cu-red);
+					background-image: -moz-linear-gradient(top, #a12756, $cu-red);
+					background-image: -o-linear-gradient(top, #a12756, $cu-red);
+					background-image: linear-gradient(to bottom, #a12756, $cu-red);
+					filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#a12756', endColorstr='#{$cu-red}',GradientType=1 );
+					font-size: 1.1em;
+					.arrow {
+						position: absolute;
+						top: 50%;
+						right: 16px;
+						margin-top: -25px;
+					}
+					&:hover {
+						background: $cu-dark-red;
+						background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2E2ZDBkZCIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM1MDliYjIiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+						background: -moz-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
+						background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, $cu-dark-red), color-stop(100%, $cu-red));
+						background: -webkit-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
+						background: -o-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
+						background: -ms-linear-gradient(top, $cu-dark-red 0%, $cu-red 100%);
+						background: linear-gradient(to bottom, $cu-dark-red 0%, $cu-red 100%);
+						filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$cu-dark-red}', endColorstr='#{$cu-red}',GradientType=0 );
+					}
+					&.long {
+						line-height: 14px;
+						padding: 10px 30px 10px 5px;
+						.arrow {
+							margin-top: -12px;
+						}
+					}
+				}
+
+			} // end redleftbutton
+		} // end editableContent
+	} // end callout
+} //end leftnavsubcontent

--- a/app/assets/stylesheets/themes/business.scss
+++ b/app/assets/stylesheets/themes/business.scss
@@ -60,4 +60,18 @@
     }
   }
 
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $asbe-primary;
+    }
+    .view-more-link {
+      background-color: $asbe-primary;
+    }
+    .view-less-link {
+      background-color: $asbe-primary;
+    }
+    .icon-triangle-up {
+      color: $asbe-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/ces.scss
+++ b/app/assets/stylesheets/themes/ces.scss
@@ -60,4 +60,19 @@
       background-color: $ces-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $ces-primary;
+    }
+    .view-more-link {
+      background-color: $ces-primary;
+    }
+    .view-less-link {
+      background-color: $ces-primary;
+    }
+    .icon-triangle-up {
+      color: $ces-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/communication.scss
+++ b/app/assets/stylesheets/themes/communication.scss
@@ -53,4 +53,19 @@
       background-color: $communication-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $communication-primary;
+    }
+    .view-more-link {
+      background-color: $communication-primary;
+    }
+    .view-less-link {
+      background-color: $communication-primary;
+    }
+    .icon-triangle-up {
+      color: $communication-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/copa.scss
+++ b/app/assets/stylesheets/themes/copa.scss
@@ -57,4 +57,19 @@
       background-color: $copa-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $copa-primary;
+    }
+    .view-more-link {
+      background-color: $copa-primary;
+    }
+    .view-less-link {
+      background-color: $copa-primary;
+    }
+    .icon-triangle-up {
+      color: $copa-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/copa__dance.scss
+++ b/app/assets/stylesheets/themes/copa__dance.scss
@@ -57,4 +57,19 @@
       background-color: $dance-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $dance-primary;
+    }
+    .view-more-link {
+      background-color: $dance-primary;
+    }
+    .view-less-link {
+      background-color: $dance-primary;
+    }
+    .icon-triangle-up {
+      color: $dance-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/copa__music.scss
+++ b/app/assets/stylesheets/themes/copa__music.scss
@@ -58,4 +58,19 @@
       background-color: $music-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $music-primary;
+    }
+    .view-more-link {
+      background-color: $music-primary;
+    }
+    .view-less-link {
+      background-color: $music-primary;
+    }
+    .icon-triangle-up {
+      color: $music-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/copa__theatre.scss
+++ b/app/assets/stylesheets/themes/copa__theatre.scss
@@ -58,4 +58,19 @@
       background-color: $theatre-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $theatre-primary;
+    }
+    .view-more-link {
+      background-color: $theatre-primary;
+    }
+    .view-less-link {
+      background-color: $theatre-primary;
+    }
+    .icon-triangle-up {
+      color: $theatre-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/crean.scss
+++ b/app/assets/stylesheets/themes/crean.scss
@@ -58,4 +58,19 @@
       background-color: $crean-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $crean-primary;
+    }
+    .view-more-link {
+      background-color: $crean-primary;
+    }
+    .view-less-link {
+      background-color: $crean-primary;
+    }
+    .icon-triangle-up {
+      color: $crean-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/dodge.scss
+++ b/app/assets/stylesheets/themes/dodge.scss
@@ -70,4 +70,19 @@
       background-color: $dodge-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $dodge-primary;
+    }
+    .view-more-link {
+      background-color: $dodge-primary;
+    }
+    .view-less-link {
+      background-color: $dodge-primary;
+    }
+    .icon-triangle-up {
+      color: $dodge-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/law.scss
+++ b/app/assets/stylesheets/themes/law.scss
@@ -250,11 +250,25 @@
             background-color: #002562;
         }
     }
-
     
     .midPhotoCallouts .photoCallout .caption,
     .photoCallouts .caption,
     .photoCallouts .rollover{
          background-color: #002f7c;
+    }
+    
+    .leftNavSubContent .callout .view-more-expander {
+        .view-more {
+            background-color: #002f7c;;
+        }
+        .view-more-link {
+            background-color: #002f7c;;
+        }
+        .view-less-link {
+            background-color: #002f7c;;
+        }
+        .icon-triangle-up {
+            color: #002f7c;;
+        }
     }
 }

--- a/app/assets/stylesheets/themes/pharmacy.scss
+++ b/app/assets/stylesheets/themes/pharmacy.scss
@@ -65,4 +65,19 @@
       background-color: $pharmacy-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $pharmacy-primary;
+    }
+    .view-more-link {
+      background-color: $pharmacy-primary;
+    }
+    .view-less-link {
+      background-color: $pharmacy-primary;
+    }
+    .icon-triangle-up {
+      color: $pharmacy-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/scst.scss
+++ b/app/assets/stylesheets/themes/scst.scss
@@ -70,4 +70,19 @@
       background-color: $scst-primary;
     }
   }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $scst-primary;
+    }
+    .view-more-link {
+      background-color: $scst-primary;
+    }
+    .view-less-link {
+      background-color: $scst-primary;
+    }
+    .icon-triangle-up {
+      color: $scst-primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/themes/wilkinson.scss
+++ b/app/assets/stylesheets/themes/wilkinson.scss
@@ -1,10 +1,8 @@
-
 #theme.wilkinson {
   @include theme-color-classes($wilkinson-primary);
   
   .smallMasthead .masthead, .smallMasthead .masthead-old, .bigMasthead .mastheadPlaceholder, .bigMasthead .masthead, .bigMasthead .masthead-old, .nameBar, .rightColumn .styleTwo {
-  	background: $wilkinson-primary; /* Old browsers */
-  	
+    background: $wilkinson-primary; /* Old browsers */
   }
 
   .rightColumn .styleTwo .border {
@@ -53,9 +51,24 @@
     background-color: $wilkinson-primary;
   }
 
-  .photoCallouts {
-    .caption, .rollover {
+    .photoCallouts {
+      .caption, .rollover {
       background-color: $wilkinson-primary;
+    }
+  }
+
+  .leftNavSubContent .callout .view-more-expander {
+    .view-more {
+      background-color: $wilkinson-primary;
+    }
+    .view-more-link {
+      background-color: $wilkinson-primary;
+    }
+    .view-less-link {
+      background-color: $wilkinson-primary;
+    }
+    .icon-triangle-up {
+      color: $wilkinson-primary;
     }
   }
 }

--- a/app/views/3_column/law_theme.html.erb
+++ b/app/views/3_column/law_theme.html.erb
@@ -7,6 +7,7 @@
     - primary_content/three_photo_callout_1
 
   left_column:
+    - left_column/shared_content_contacts_3.html
     - left_column/callout_1
     - left_column/callout_2
     - left_column/callout_3

--- a/app/views/3_column/sample-college.html.erb
+++ b/app/views/3_column/sample-college.html.erb
@@ -18,6 +18,7 @@
     - primary_content/logo_image_rotator_1
 
   left_column:
+    - left_column/shared_content_contacts_3.html
     - left_column/callout_1
     - left_column/callout_2
     - left_column/callout_3

--- a/app/views/3_column/sample.html.erb
+++ b/app/views/3_column/sample.html.erb
@@ -22,6 +22,8 @@
 
   left_column:
     - left_column/shared_content_contacts_3.html
+    - left_column/shared_content_contacts_2.html
+    - left_column/shared_content_contacts_1.html	
     - left_column/callout_1
     - left_column/callout_2
     - left_column/callout_3

--- a/app/views/widgets/left_column/_shared_content_contacts_1.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_1.html
@@ -1,57 +1,95 @@
-<!--- this version has the optional Individual Contacts at the bottom --->
+<!--- this version has the optional Individual Contacts at the bottom; had NO social icons --->
 <div class="callout-box-widget--left callout">
 	<div class="border"> </div>
     <h2>Contact Information</h2>
-    <div class="editableContent">
-        <p>Strategic Marketing &amp; Communication</p> 
+    
+    <div class="contact-widget">
+    	<div class="editableContent">
+            <h3>Strategic Marketing &amp; Communication</h3> 
+            
+            <p>Main:
+                <br/><a href="tel:7149976661">(714) 997-6661</a>
+                <br/><a href="mailto:smc@chapman.edu">smc@chapman.edu</a>
+            </p>
+            
+            <div>Hours:</div>
+            <!--- note the Hours field is a wysiwyg so don't know if they'll have P tag around it or not. Use div so not embedded P tags --->
+            <div><p>8 a.m. to 5 p.m.</p></div>
+                                
+            <h4>Location</h4>            
+            <p>633 West Palm
+               <br/>Suite 118A 
+               <br/>Orange, CA 92866
+            </p>
+    
+            <div class="more-content inactive">
+                <h4>Mailing Address</h4>
+                
+                <p>Strategic Marketing &amp; Communication
+                   <br/>Chapman University
+                   <br/>One University Drive 
+                   <br/>Orange, CA 92866
+                </p>
         
-        <p>Main:
-            <br/><a href="tel:7149976661">(714) 997-6661</a>
-            <br/><a href="mailto:smc@chapman.edu">smc@chapman.edu</a>
-        </p>
-        <p>Hours:
-                <br/>8 a.m. to 5 p.m.
-        </p>
-                            
-        <h3>Location</h3>
-        
-        <p>633 West Palm
-           <br/>Suite 118A 
-           <br/>Orange, CA 92866
-        </p>
-
-        <h3>Mailing Address</h3>
-        
-        <p>Strategic Marketing &amp; Communication
-           <br/>Chapman University
-           <br/>One University Drive 
-           <br/>Orange, CA 92866
-        </p>
-
-		<h3>Individual Contact(s)</h3> 
-        <p>
+                <h4>Individual Contact(s)</h4> 
+                <p>
                     Esther Choi
                     <br/>Account Manager
                     <br/><a href="tel:7149976582">(714) 997-6582</a> 
                     <br/><a href="mailto:echoi@chapman.edu">echoi@chapman.edu</a>                                  
-        </p>
-        <p>
+                </p>
+                <p>
                     Drew Farrington
                     <br/>Account Manager
                     <br/><a href="tel:7142893142">(714) 289-3142</a> 
                     <br/><a href="mailto:afarring@chapman.edu">afarring@chapman.edu</a>                                  
-        </p>
-        <p>
+                </p>
+                <p>
                     Carl Minor
                     <br/>Account Manager
                     <br/><a href="tel:7146287214">(714) 628-7214</a> 
                     <br/><a href="mailto:cminor@chapman.edu">cminor@chapman.edu</a>                                  
-        </p>
-        <p>
+                </p>
+                <p>
                     Gina Madson
                     <br/>Account Manager
                     <br/><a href="tel:7147447961">(714) 744-7961</a> 
                     <br/><a href="mailto:madson@chapman.edu">madson@chapman.edu</a>                                  
-        </p>
-	</div>
-</div>
+                </p>
+            </div>  
+    	
+        </div> <!-- end editableContent -->
+    	
+        <div class="view-more-expander"> 
+            <a class="view-more active">
+                <span class="icon icon-triangle-down">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+							<symbol id="icon-triangle-down" viewBox="0 0 12 16">
+								<title>triangle-down</title>
+								<path d="M0,7l6,4l6-4C12,7,0,7,0,7z"></path>
+							</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-down"><use xlink:href="#icon-triangle-down"></use></svg>
+                </span>
+                <div class="view-more-link">View More</div>
+            </a>
+            
+            <a class="view-less inactive">
+                <span class="icon icon-triangle-up">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+						<symbol id="icon-triangle-up" viewBox="0 0 12 16">
+							<title>triangle-up</title>
+							<path d="M6,6l-6,4h12L6,6z"></path>
+						</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-up"><use xlink:href="#icon-triangle-up"></use></svg>
+                </span>
+                <div class="view-less-link">View Less</div>
+            </a>
+        </div>
+	</div> <!-- end contact-widget -->
+</div> <!-- end callout-box-widget--left -->

--- a/app/views/widgets/left_column/_shared_content_contacts_2.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_2.html
@@ -1,44 +1,154 @@
-<!--- this version has additional (optional) contacts after "Main" --->
+<!--- this version has additional (optional) contacts after "Main"; has 5 of 9 social icons --->
 <div class="callout-box-widget--left callout">
 	<div class="border"> </div>
     <h2>Contact Information</h2>
-    <div class="editableContent">
-    	<p>Information Systems &amp; Technology</p> 
+    
+    <div class="contact-widget">
+    	<div class="editableContent">
+            <h3>Information Systems &amp; Technology</h3> 
+                    
+            <p>Main:
+                <br/><a href="tel:7149976600">(714) 997-6600</a>
+                <br/><a href="mailto:servicedesk@chapman.edu">servicedesk@chapman.edu</a>
+            </p>  
+            
+            <p>Front Desk:
+                <br/><a href="tel:7149976726">714-997-6726</a>                  
+            </p>
+            <p>Information Security:
+                <br/><a href="tel:7147447972">714-744-7972</a> 
+                <br/><a href="mailto:infoSec@chapman.edu">infoSec@chapman.edu</a>  
+            </p>         
+                                                        
+            <div>Hours:</div>
+            <!--- note the Hours field is a wysiwyg so don't know if they'll have P tag around it or not. Use div so not embedded P tags --->
+            <div><p>Office open for walk-in 8:00am to 12noon, 1:00pm to 5:00pm. Closed from 12noon to 1:00pm for lunch.</p></div>
                 
-        <p>Main:
-            <br/><a href="tel:7149976600">(714) 997-6600</a>
-            <br/><a href="mailto:servicedesk@chapman.edu">servicedesk@chapman.edu</a>
-        </p>
-                
-        <p>
-            Front Desk
-            <br/><a href="tel:${suppPhoneS}">714-997-6726</a> 
-            <br/><a href="mailto:"></a>  
-        </p>
-        <p>
-            Information Security
-            <br/><a href="tel:${suppPhoneS}">714-744-7972</a> 
-            <br/><a href="mailto:infoSec@chapman.edu">infoSec@chapman.edu</a>  
-        </p>
-                                                    
-                                                    <p>Hours:
-                        <br/><p>Office open for walk-in 8:00am to 12noon, 1:00pm to 5:00pm. Closed from 12noon to 1:00pm for lunch hour.</p>
-                    </p>
-                                    
-                <h3>Location</h3>
-                <p>
-                    635 W. Palm Ave.
-                                        <br/>Orange, CA 92866
-                                                               <br/><a href="https://www.chapman.edu/about/maps-directions/campus-map/index.aspx?s=subCat-a713d6dbc04d744c291bfe8353b34cb3">View Map</a>
-                                    </p>
-
-                <h3>Mailing Address</h3>
-                <p>
-                    Information Systems &amp; Technology
+            <h4>Location</h4>            
+            <p>635 West Palm
+               <br/>Orange, CA 92866
+               <br/><a href="https://www.chapman.edu/about/maps-directions/campus-map/index.aspx?s=subCat-a713d6dbc04d744c291bfe8353b34cb3">View Map</a>
+            </p>
+    
+            <div class="more-content inactive">
+                <h4>Mailing Address</h4>
+                <p>Information Systems &amp; Technology
                     <br/>Chapman University
-                                            <br/>One University Drive 
-                                        <br/>Orange, CA 92866
-                                    </p>
+                    <br/>One University Drive 
+                    <br/>Orange, CA 92866
+                </p>         
+            </div>
+            
+            <div class="social-follow-us">
+                <h4>Follow Us</h4>
+                <ul class="left-social-icons">
+                    <li>
+                    	<a href="https://www.facebook.com/ChapmanUniversity/" title="facebook">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+								<symbol id="icon-facebook" viewBox="0 0 16 16">
+									<title>facebook</title>
+									<path d="M9.5 3h2.5v-3h-2.5c-1.93 0-3.5 1.57-3.5 3.5v1.5h-2v3h2v8h3v-8h2.5l0.5-3h-3v-1.5c0-0.271 0.229-0.5 0.5-0.5z"></path>
+								</symbol>
 
-                                            </div>
-    </div>
+							</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-facebook"></use></svg>
+                    	</a>
+                    </li>
+                    <li>
+                    	<a href="https://twitter.com/chapmanu" title="twitter">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+								<symbol id="icon-twitter" viewBox="0 0 16 16">
+									<title>twitter</title>
+									<path d="M16 3.538c-0.588 0.263-1.222 0.438-1.884 0.516 0.678-0.406 1.197-1.050 1.444-1.816-0.634 0.375-1.338 0.65-2.084 0.797-0.6-0.638-1.453-1.034-2.397-1.034-1.813 0-3.281 1.469-3.281 3.281 0 0.256 0.028 0.506 0.084 0.747-2.728-0.138-5.147-1.444-6.766-3.431-0.281 0.484-0.444 1.050-0.444 1.65 0 1.138 0.578 2.144 1.459 2.731-0.538-0.016-1.044-0.166-1.488-0.409 0 0.013 0 0.028 0 0.041 0 1.591 1.131 2.919 2.634 3.219-0.275 0.075-0.566 0.116-0.866 0.116-0.212 0-0.416-0.022-0.619-0.059 0.419 1.303 1.631 2.253 3.066 2.281-1.125 0.881-2.538 1.406-4.078 1.406-0.266 0-0.525-0.016-0.784-0.047 1.456 0.934 3.181 1.475 5.034 1.475 6.037 0 9.341-5.003 9.341-9.341 0-0.144-0.003-0.284-0.009-0.425 0.641-0.459 1.197-1.038 1.637-1.697z"></path>
+								</symbol>
+
+							</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-twitter"></use></svg>
+                    	</a>
+                    </li>    
+                    <li>
+                    	<a href="https://instagram.com/chapmanufamily" title="instagram">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+									<symbol id="icon-instagram" viewBox="0 0 16 16">
+										<title>instagram</title>
+										<path d="M8 1.441c2.137 0 2.391 0.009 3.231 0.047 0.781 0.034 1.203 0.166 1.484 0.275 0.372 0.144 0.641 0.319 0.919 0.597 0.281 0.281 0.453 0.547 0.6 0.919 0.109 0.281 0.241 0.706 0.275 1.484 0.037 0.844 0.047 1.097 0.047 3.231s-0.009 2.391-0.047 3.231c-0.034 0.781-0.166 1.203-0.275 1.484-0.144 0.372-0.319 0.641-0.597 0.919-0.281 0.281-0.547 0.453-0.919 0.6-0.281 0.109-0.706 0.241-1.484 0.275-0.844 0.037-1.097 0.047-3.231 0.047s-2.391-0.009-3.231-0.047c-0.781-0.034-1.203-0.166-1.484-0.275-0.372-0.144-0.641-0.319-0.919-0.597-0.281-0.281-0.453-0.547-0.6-0.919-0.109-0.281-0.241-0.706-0.275-1.484-0.038-0.844-0.047-1.097-0.047-3.231s0.009-2.391 0.047-3.231c0.034-0.781 0.166-1.203 0.275-1.484 0.144-0.372 0.319-0.641 0.597-0.919 0.281-0.281 0.547-0.453 0.919-0.6 0.281-0.109 0.706-0.241 1.484-0.275 0.841-0.038 1.094-0.047 3.231-0.047zM8 0c-2.172 0-2.444 0.009-3.297 0.047-0.85 0.038-1.434 0.175-1.941 0.372-0.528 0.206-0.975 0.478-1.419 0.925-0.447 0.444-0.719 0.891-0.925 1.416-0.197 0.509-0.334 1.091-0.372 1.941-0.037 0.856-0.047 1.128-0.047 3.3s0.009 2.444 0.047 3.297c0.038 0.85 0.175 1.434 0.372 1.941 0.206 0.528 0.478 0.975 0.925 1.419 0.444 0.444 0.891 0.719 1.416 0.922 0.509 0.197 1.091 0.334 1.941 0.372 0.853 0.037 1.125 0.047 3.297 0.047s2.444-0.009 3.297-0.047c0.85-0.037 1.434-0.175 1.941-0.372 0.525-0.203 0.972-0.478 1.416-0.922s0.719-0.891 0.922-1.416c0.197-0.509 0.334-1.091 0.372-1.941 0.037-0.853 0.047-1.125 0.047-3.297s-0.009-2.444-0.047-3.297c-0.037-0.85-0.175-1.434-0.372-1.941-0.197-0.531-0.469-0.978-0.916-1.422-0.444-0.444-0.891-0.719-1.416-0.922-0.509-0.197-1.091-0.334-1.941-0.372-0.856-0.041-1.128-0.050-3.3-0.050v0z"></path>
+										<path d="M8 3.891c-2.269 0-4.109 1.841-4.109 4.109s1.841 4.109 4.109 4.109 4.109-1.841 4.109-4.109c0-2.269-1.841-4.109-4.109-4.109zM8 10.666c-1.472 0-2.666-1.194-2.666-2.666s1.194-2.666 2.666-2.666c1.472 0 2.666 1.194 2.666 2.666s-1.194 2.666-2.666 2.666z"></path>
+										<path d="M13.231 3.728c0 0.53-0.43 0.959-0.959 0.959s-0.959-0.43-0.959-0.959c0-0.53 0.43-0.959 0.959-0.959s0.959 0.43 0.959 0.959z"></path>
+									</symbol>
+								</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-instagram"></use></svg>
+                    	</a>
+                    </li> 
+                    <li>
+                    	<a href="#" title="linkedin">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-linkedin" viewBox="0 0 16 16">
+                                        <title>linkedin</title>
+                                        <path d="M6 6h2.767v1.418h0.040c0.385-0.691 1.327-1.418 2.732-1.418 2.921 0 3.461 1.818 3.461 4.183v4.817h-2.885v-4.27c0-1.018-0.021-2.329-1.5-2.329-1.502 0-1.732 1.109-1.732 2.255v4.344h-2.883v-9z"></path>
+										<path d="M1 6h3v9h-3v-9z"></path>
+										<path d="M4 3.5c0 0.828-0.672 1.5-1.5 1.5s-1.5-0.672-1.5-1.5c0-0.828 0.672-1.5 1.5-1.5s1.5 0.672 1.5 1.5z"></path>
+                                    </symbol>
+    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-linkedin"></use></svg>
+                    	</a>
+                    </li>                   
+                    <li class="last">
+                    	<a href="https://blogs.chapman.edu/happenings/" title="blog">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-blog" viewBox="0 0 16 16">
+                                        <title>blog</title>
+                                        <path d="M2.13 11.733c-1.175 0-2.13 0.958-2.13 2.126 0 1.174 0.955 2.122 2.13 2.122 1.179 0 2.133-0.948 2.133-2.122-0-1.168-0.954-2.126-2.133-2.126zM0.002 5.436v3.067c1.997 0 3.874 0.781 5.288 2.196 1.412 1.411 2.192 3.297 2.192 5.302h3.080c-0-5.825-4.739-10.564-10.56-10.564zM0.006 0v3.068c7.122 0 12.918 5.802 12.918 12.932h3.076c0-8.82-7.176-16-15.994-16z"></path>
+                                    </symbol>    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-blog"></use></svg>
+                    	</a>
+                    </li>           
+                </ul>   
+            </div> 
+        
+        </div> <!-- end editableContent -->
+    	
+        <div class="view-more-expander"> 
+            <a class="view-more active">
+                <span class="icon icon-triangle-down">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+							<symbol id="icon-triangle-down" viewBox="0 0 12 16">
+								<title>triangle-down</title>
+								<path d="M0,7l6,4l6-4C12,7,0,7,0,7z"></path>
+							</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-down"><use xlink:href="#icon-triangle-down"></use></svg>
+                </span>
+                <div class="view-more-link">View More</div>
+            </a>
+            
+            <a class="view-less inactive">
+                <span class="icon icon-triangle-up">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+						<symbol id="icon-triangle-up" viewBox="0 0 12 16">
+							<title>triangle-up</title>
+							<path d="M6,6l-6,4h12L6,6z"></path>
+						</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-up"><use xlink:href="#icon-triangle-up"></use></svg>
+                </span>
+                <div class="view-less-link">View Less</div>
+            </a>
+        </div>
+	</div> <!-- end contact-widget -->
+</div> <!-- end callout-box-widget--left -->

--- a/app/views/widgets/left_column/_shared_content_contacts_3.html
+++ b/app/views/widgets/left_column/_shared_content_contacts_3.html
@@ -1,37 +1,240 @@
-<!--- this version has the social follow us image/links at top --->
+<!--- this version has the social follow us image/links at top; had all 9 social icons --->
 <div class="callout-box-widget--left callout">
 	<div class="border"> </div>     
 	<h2>Contact Information</h2>
-    
-	<div id="social_follow_us">
-    	<div class="banner"></div>
-        <ul>
-            <li class="facebook first"><span class="inactive_state"></span><span class="hover_state"></span><a href="https://www.facebook.com/SchmidCollegeOfScienceTechnologyChapmanUniversity?fref=ts"><span class="hide">facebook</span></a></li>
-            <li class="blog"><span class="inactive_state"></span><span class="hover_state"></span><a href="http://blogs.chapman.edu/scst/"><span class="hide">blog</span></a></li>
-            <li class="youtube last"><span class="inactive_state"></span><span class="hover_state"></span><a href="https://www.youtube.com/watch?v=PIuSc7mOnzc&amp;list=PLBAF625333A86D39F"><span class="hide">youtube</span></a></li>    
-        </ul>
-	</div>
                     
-    <div class="editableContent">
-        <p>Schmid College of Science &amp; Technology</p> 
+    <div class="contact-widget">
+    	<div class="editableContent">
+            <h3>Schmid College of Science and Technology</h3> 
+                
+            <p>Main:
+               <br/><a href="tel:7146287318">(714) 628-7318</a>
+               <br/><a href="mailto:schmidcollege@chapman.edu">schmidcollege@chapman.edu</a>
+            </p>
             
-        <p>Main:
-           <br/><a href="tel:7146287318">(714) 628-7318</a>
-           <br/><a href="mailto:schmidcollege@chapman.edu">schmidcollege@chapman.edu</a>
-        </p>
+            <h4>Location</h4>
+            
+            <p>Moulton Hall
+                <br/>Chapman Campus
+                <br/>Orange, CA 92866
+            </p>        
+            
+            <div class="more-content inactive">
+            
+                <h4>Mailing Address</h4>        
+                <p>Schmid College of Science &amp; Technology
+                   <br/>Chapman University
+                   <br/>One University Drive 
+                   <br/>Orange, CA 92866
+                </p>
+            
+                <h4>Individual Contact(s)</h4> 
+                <p>
+                    Esther Choi
+                    <br/>Account Manager
+                    <br/><a href="tel:7149976582">(714) 997-6582</a> 
+                    <br/><a href="mailto:echoi@chapman.edu">echoi@chapman.edu</a>                                  
+                </p>
+                <p>
+                    Drew Farrington
+                    <br/>Account Manager
+                    <br/><a href="tel:7142893142">(714) 289-3142</a> 
+                    <br/><a href="mailto:afarring@chapman.edu">afarring@chapman.edu</a>                                  
+                </p>
+                <p>
+                    Carl Minor
+                    <br/>Account Manager
+                    <br/><a href="tel:7146287214">(714) 628-7214</a> 
+                    <br/><a href="mailto:cminor@chapman.edu">cminor@chapman.edu</a>                                  
+                </p>
+                <p>
+                    Gina Madson
+                    <br/>Account Manager
+                    <br/><a href="tel:7147447961">(714) 744-7961</a> 
+                    <br/><a href="mailto:madson@chapman.edu">madson@chapman.edu</a>                                  
+                </p>        
+        	</div>
         
-        <h3>Location</h3>
-        
-        <p>One University Drive
-           <br/>Orange, CA 92866
-        </p>
+        	<div class="social-follow-us">
+                <h4>Follow Us</h4>
+                <ul class="left-social-icons">
+                    <li>
+                    	<a href="https://www.facebook.com/ChapmanUniversity/" title="facebook">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+								<symbol id="icon-facebook" viewBox="0 0 16 16">
+									<title>facebook</title>
+									<path d="M9.5 3h2.5v-3h-2.5c-1.93 0-3.5 1.57-3.5 3.5v1.5h-2v3h2v8h3v-8h2.5l0.5-3h-3v-1.5c0-0.271 0.229-0.5 0.5-0.5z"></path>
+								</symbol>
 
-        <h3>Mailing Address</h3>
-        
-        <p>Schmid College of Science &amp; Technology
-           <br/>Chapman University
-           <br/>One University Drive 
-           <br/>Orange, CA 92866
-        </p>
-    </div>    
-</div>
+							</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-facebook"></use></svg>
+                    	</a>
+                    </li>
+                    <li>
+                    	<a href="https://twitter.com/chapmanu" title="twitter">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+								<symbol id="icon-twitter" viewBox="0 0 16 16">
+									<title>twitter</title>
+									<path d="M16 3.538c-0.588 0.263-1.222 0.438-1.884 0.516 0.678-0.406 1.197-1.050 1.444-1.816-0.634 0.375-1.338 0.65-2.084 0.797-0.6-0.638-1.453-1.034-2.397-1.034-1.813 0-3.281 1.469-3.281 3.281 0 0.256 0.028 0.506 0.084 0.747-2.728-0.138-5.147-1.444-6.766-3.431-0.281 0.484-0.444 1.050-0.444 1.65 0 1.138 0.578 2.144 1.459 2.731-0.538-0.016-1.044-0.166-1.488-0.409 0 0.013 0 0.028 0 0.041 0 1.591 1.131 2.919 2.634 3.219-0.275 0.075-0.566 0.116-0.866 0.116-0.212 0-0.416-0.022-0.619-0.059 0.419 1.303 1.631 2.253 3.066 2.281-1.125 0.881-2.538 1.406-4.078 1.406-0.266 0-0.525-0.016-0.784-0.047 1.456 0.934 3.181 1.475 5.034 1.475 6.037 0 9.341-5.003 9.341-9.341 0-0.144-0.003-0.284-0.009-0.425 0.641-0.459 1.197-1.038 1.637-1.697z"></path>
+								</symbol>
+
+							</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-twitter"></use></svg>
+                    	</a>
+                    </li>    
+                    <li>
+                    	<a href="https://instagram.com/chapmanufamily" title="instagram">
+                    		<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+								<defs>
+									<symbol id="icon-instagram" viewBox="0 0 16 16">
+										<title>instagram</title>
+										<path d="M8 1.441c2.137 0 2.391 0.009 3.231 0.047 0.781 0.034 1.203 0.166 1.484 0.275 0.372 0.144 0.641 0.319 0.919 0.597 0.281 0.281 0.453 0.547 0.6 0.919 0.109 0.281 0.241 0.706 0.275 1.484 0.037 0.844 0.047 1.097 0.047 3.231s-0.009 2.391-0.047 3.231c-0.034 0.781-0.166 1.203-0.275 1.484-0.144 0.372-0.319 0.641-0.597 0.919-0.281 0.281-0.547 0.453-0.919 0.6-0.281 0.109-0.706 0.241-1.484 0.275-0.844 0.037-1.097 0.047-3.231 0.047s-2.391-0.009-3.231-0.047c-0.781-0.034-1.203-0.166-1.484-0.275-0.372-0.144-0.641-0.319-0.919-0.597-0.281-0.281-0.453-0.547-0.6-0.919-0.109-0.281-0.241-0.706-0.275-1.484-0.038-0.844-0.047-1.097-0.047-3.231s0.009-2.391 0.047-3.231c0.034-0.781 0.166-1.203 0.275-1.484 0.144-0.372 0.319-0.641 0.597-0.919 0.281-0.281 0.547-0.453 0.919-0.6 0.281-0.109 0.706-0.241 1.484-0.275 0.841-0.038 1.094-0.047 3.231-0.047zM8 0c-2.172 0-2.444 0.009-3.297 0.047-0.85 0.038-1.434 0.175-1.941 0.372-0.528 0.206-0.975 0.478-1.419 0.925-0.447 0.444-0.719 0.891-0.925 1.416-0.197 0.509-0.334 1.091-0.372 1.941-0.037 0.856-0.047 1.128-0.047 3.3s0.009 2.444 0.047 3.297c0.038 0.85 0.175 1.434 0.372 1.941 0.206 0.528 0.478 0.975 0.925 1.419 0.444 0.444 0.891 0.719 1.416 0.922 0.509 0.197 1.091 0.334 1.941 0.372 0.853 0.037 1.125 0.047 3.297 0.047s2.444-0.009 3.297-0.047c0.85-0.037 1.434-0.175 1.941-0.372 0.525-0.203 0.972-0.478 1.416-0.922s0.719-0.891 0.922-1.416c0.197-0.509 0.334-1.091 0.372-1.941 0.037-0.853 0.047-1.125 0.047-3.297s-0.009-2.444-0.047-3.297c-0.037-0.85-0.175-1.434-0.372-1.941-0.197-0.531-0.469-0.978-0.916-1.422-0.444-0.444-0.891-0.719-1.416-0.922-0.509-0.197-1.091-0.334-1.941-0.372-0.856-0.041-1.128-0.050-3.3-0.050v0z"></path>
+										<path d="M8 3.891c-2.269 0-4.109 1.841-4.109 4.109s1.841 4.109 4.109 4.109 4.109-1.841 4.109-4.109c0-2.269-1.841-4.109-4.109-4.109zM8 10.666c-1.472 0-2.666-1.194-2.666-2.666s1.194-2.666 2.666-2.666c1.472 0 2.666 1.194 2.666 2.666s-1.194 2.666-2.666 2.666z"></path>
+										<path d="M13.231 3.728c0 0.53-0.43 0.959-0.959 0.959s-0.959-0.43-0.959-0.959c0-0.53 0.43-0.959 0.959-0.959s0.959 0.43 0.959 0.959z"></path>
+									</symbol>
+								</defs>
+							</svg>
+							<svg class="icon"><use xlink:href="#icon-instagram"></use></svg>
+                    	</a>
+                    </li> 
+                    <li>
+                    	<a href="#" title="linkedin">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-linkedin" viewBox="0 0 16 16">
+                                        <title>linkedin</title>
+                                        <path d="M6 6h2.767v1.418h0.040c0.385-0.691 1.327-1.418 2.732-1.418 2.921 0 3.461 1.818 3.461 4.183v4.817h-2.885v-4.27c0-1.018-0.021-2.329-1.5-2.329-1.502 0-1.732 1.109-1.732 2.255v4.344h-2.883v-9z"></path>
+										<path d="M1 6h3v9h-3v-9z"></path>
+										<path d="M4 3.5c0 0.828-0.672 1.5-1.5 1.5s-1.5-0.672-1.5-1.5c0-0.828 0.672-1.5 1.5-1.5s1.5 0.672 1.5 1.5z"></path>
+                                    </symbol>
+    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-linkedin"></use></svg>
+                    	</a>
+                    </li> 
+                    <li>
+                    	<a href="#" title="youtube">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-youtube" viewBox="0 0 16 16">
+                                        <title>youtube</title>
+                                        <path d="M15.841 4.8c0 0-0.156-1.103-0.637-1.587-0.609-0.637-1.291-0.641-1.603-0.678-2.237-0.163-5.597-0.163-5.597-0.163h-0.006c0 0-3.359 0-5.597 0.163-0.313 0.038-0.994 0.041-1.603 0.678-0.481 0.484-0.634 1.587-0.634 1.587s-0.159 1.294-0.159 2.591v1.213c0 1.294 0.159 2.591 0.159 2.591s0.156 1.103 0.634 1.588c0.609 0.637 1.409 0.616 1.766 0.684 1.281 0.122 5.441 0.159 5.441 0.159s3.363-0.006 5.6-0.166c0.313-0.037 0.994-0.041 1.603-0.678 0.481-0.484 0.637-1.588 0.637-1.588s0.159-1.294 0.159-2.591v-1.213c-0.003-1.294-0.162-2.591-0.162-2.591zM6.347 10.075v-4.497l4.322 2.256-4.322 2.241z"></path>
+                                    </symbol>
+    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-youtube"></use></svg>
+                    	</a>
+                    </li>    
+                    <li>
+                    	<a href="#" title="pinterest">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-pinterest" viewBox="0 0 16 16">
+                                        <title>pinterest</title>
+                                        <path d="M8 0c-4.412 0-8 3.587-8 8s3.587 8 8 8 8-3.588 8-8-3.588-8-8-8zM8 14.931c-0.716 0-1.403-0.109-2.053-0.309 0.281-0.459 0.706-1.216 0.862-1.816 0.084-0.325 0.431-1.647 0.431-1.647 0.225 0.431 0.888 0.797 1.587 0.797 2.091 0 3.597-1.922 3.597-4.313 0-2.291-1.869-4.003-4.272-4.003-2.991 0-4.578 2.009-4.578 4.194 0 1.016 0.541 2.281 1.406 2.684 0.131 0.063 0.2 0.034 0.231-0.094 0.022-0.097 0.141-0.566 0.194-0.787 0.016-0.069 0.009-0.131-0.047-0.2-0.287-0.347-0.516-0.988-0.516-1.581 0-1.528 1.156-3.009 3.128-3.009 1.703 0 2.894 1.159 2.894 2.819 0 1.875-0.947 3.175-2.178 3.175-0.681 0-1.191-0.563-1.025-1.253 0.197-0.825 0.575-1.713 0.575-2.306 0-0.531-0.284-0.975-0.878-0.975-0.697 0-1.253 0.719-1.253 1.684 0 0.612 0.206 1.028 0.206 1.028s-0.688 2.903-0.813 3.444c-0.141 0.6-0.084 1.441-0.025 1.988-2.578-1.006-4.406-3.512-4.406-6.45 0-3.828 3.103-6.931 6.931-6.931s6.931 3.103 6.931 6.931c0 3.828-3.103 6.931-6.931 6.931z"></path>
+                                    </symbol>
+    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-pinterest"></use></svg>
+                    	</a>
+                    </li>              
+                    <li>
+                    	<a href="#" title="vimeo">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-vimeo" viewBox="0 0 16 16">
+                                        <title>vimeo</title>
+                                        <path d="M15.994 4.281c-0.072 1.556-1.159 3.691-3.263 6.397-2.175 2.825-4.016 4.241-5.522 4.241-0.931 0-1.722-0.859-2.366-2.581-0.431-1.578-0.859-3.156-1.291-4.734-0.478-1.722-0.991-2.581-1.541-2.581-0.119 0-0.538 0.253-1.256 0.753l-0.753-0.969c0.791-0.694 1.569-1.388 2.334-2.081 1.053-0.909 1.844-1.387 2.372-1.438 1.244-0.119 2.013 0.731 2.3 2.553 0.309 1.966 0.525 3.188 0.647 3.666 0.359 1.631 0.753 2.447 1.184 2.447 0.334 0 0.838-0.528 1.509-1.588 0.669-1.056 1.028-1.862 1.078-2.416 0.097-0.912-0.262-1.372-1.078-1.372-0.384 0-0.778 0.088-1.184 0.263 0.787-2.575 2.287-3.825 4.506-3.753 1.641 0.044 2.416 1.109 2.322 3.194z"></path>
+                                    </symbol>    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-vimeo"></use></svg>
+                    	</a>
+                    </li>
+                    <li>
+                    	<a href="https://www.snapchat.com/add/chapmanu" title="snapchat">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-snapchat" viewBox="0 0 26 28">
+                                        <title>snapchat</title>
+                                        <path d="M13.25 2c2.812-0.031 5.141 1.547 6.312 4.078 0.359 0.766 0.422 1.953 0.422 2.797 0 1-0.078 1.984-0.141 2.984 0.125 0.063 0.297 0.109 0.438 0.109 0.562 0 1.031-0.422 1.594-0.422 0.531 0 1.297 0.375 1.297 1 0 1.5-3.141 1.219-3.141 2.531 0 0.234 0.094 0.453 0.187 0.672 0.75 1.641 2.172 3.219 3.859 3.922 0.406 0.172 0.812 0.266 1.25 0.359 0.281 0.063 0.438 0.266 0.438 0.547 0 1.062-2.703 1.5-3.422 1.609-0.313 0.484-0.078 1.625-0.906 1.625-0.641 0-1.281-0.203-1.969-0.203-0.328 0-0.656 0.016-0.969 0.078-1.859 0.313-2.484 2.312-5.531 2.312-2.938 0-3.641-2-5.453-2.312-0.328-0.063-0.656-0.078-0.984-0.078-0.703 0-1.375 0.234-1.937 0.234-0.875 0-0.609-1.156-0.938-1.656-0.719-0.109-3.422-0.547-3.422-1.609 0-0.281 0.156-0.484 0.438-0.547 0.438-0.094 0.844-0.187 1.25-0.359 1.672-0.688 3.125-2.281 3.859-3.922 0.094-0.219 0.187-0.438 0.187-0.672 0-1.313-3.156-1.062-3.156-2.516 0-0.609 0.719-1 1.266-1 0.484 0 0.969 0.406 1.578 0.406 0.172 0 0.344-0.031 0.5-0.109-0.063-0.984-0.141-1.969-0.141-2.969 0-0.844 0.063-2.047 0.422-2.812 1.375-2.969 3.703-4.047 6.813-4.078z"></path>
+                                    </symbol>    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-snapchat"></use></svg>
+                    	</a>
+                    </li>  
+                    <li class="last">
+                    	<a href="https://blogs.chapman.edu/happenings/" title="blog">
+							<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <defs>
+                                    <symbol id="icon-blog" viewBox="0 0 16 16">
+                                        <title>blog</title>
+                                        <path d="M2.13 11.733c-1.175 0-2.13 0.958-2.13 2.126 0 1.174 0.955 2.122 2.13 2.122 1.179 0 2.133-0.948 2.133-2.122-0-1.168-0.954-2.126-2.133-2.126zM0.002 5.436v3.067c1.997 0 3.874 0.781 5.288 2.196 1.412 1.411 2.192 3.297 2.192 5.302h3.080c-0-5.825-4.739-10.564-10.56-10.564zM0.006 0v3.068c7.122 0 12.918 5.802 12.918 12.932h3.076c0-8.82-7.176-16-15.994-16z"></path>
+                                    </symbol>    
+                                </defs>
+                            </svg>
+                            <svg class="icon"><use xlink:href="#icon-blog"></use></svg>
+                    	</a>
+                    </li>           
+                </ul>  
+            </div>  
+            
+            <!-- old version using icomoon fonts:
+            <div class="social-follow-us">
+                <h3>Follow Us (icomoon font version)</h3>
+                <ul class="left-social-icons">
+                    <li><a href="https://www.facebook.com/ChapmanUniversity/" title="Facebook"><span class="icon-facebook"></span><span style="display:none;">Facebook</span></a></li>
+                    <li><a href="https://twitter.com/chapmanu" title="Twitter"><span class="icon icon-twitter"></span><span style="display:none;">Twitter</span></a></li>    
+                    <li><a href="https://instagram.com/chapmanufamily" title="Instagram"><span class="icon icon-instagram"></span><span style="display:none;">Instagram</span></a></li>
+                    <li><a href="#" title="Linked In"><span class="icon icon-linkedin2"></span><span style="display:none;">Linked In</span></a></li> 
+                    <li><a href="#" title="youTube"><span class="icon icon-youtube2"></span><span style="display:none;">youTube</span></a></li>    
+                    <li><a href="#" title="Pinterest"><span class="icon icon-pinterest"></span><span style="display:none;">Pinterest</span></a></li>             
+                    <li><a href="#" title="Vimeo"><span class="icon icon-vimeo"></span><span style="display:none;">Vimeo</span></a></li> 
+                    <li><a href="https://www.snapchat.com/add/chapmanu" title="Snapchat"><span class="icon icon-snapchat-ghost"></span></a><span style="display:none;">Snapchat</span></li>  
+                    <li class="last"><a href="https://blogs.chapman.edu/happenings/" title="Blog"><span class="icon icon-rss"></span><span style="display:none;">Blog</span></a></li>           
+                </ul>  
+            </div>
+            -->    
+        </div> <!-- end editableContent -->
+    	
+        <div class="view-more-expander"> 
+            <a class="view-more active">
+                <span class="icon icon-triangle-down">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+							<symbol id="icon-triangle-down" viewBox="0 0 12 16">
+								<title>triangle-down</title>
+								<path d="M0,7l6,4l6-4C12,7,0,7,0,7z"></path>
+							</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-down"><use xlink:href="#icon-triangle-down"></use></svg>
+                </span>
+                <div class="view-more-link">View More</div>
+            </a>
+            
+            <a class="view-less inactive">
+                <span class="icon icon-triangle-up">
+                	<svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+						<defs>
+						<symbol id="icon-triangle-up" viewBox="0 0 12 16">
+							<title>triangle-up</title>
+							<path d="M6,6l-6,4h12L6,6z"></path>
+						</symbol>
+						</defs>
+					</svg>
+					<svg class="icon icon-triangle-up"><use xlink:href="#icon-triangle-up"></use></svg>
+                </span>
+                <div class="view-less-link">View Less</div>
+            </a>
+        </div>
+	</div> <!-- end contact-widget -->
+</div> <!-- end callout-box-widget--left -->


### PR DESCRIPTION
adding new widget for Dept Contacts which uses shared content blocks in Cascade. New sample snippets for 2 and 3 Column pages for localhost testing, new SVG for social follow us icons, new JS for view more/less expander on widget; update to school themes for same widget