### PR TITLE
Some 3-column template pages on www are appearing with margins and column widths not consistent with the standard.

### DIFF
--- a/app/assets/stylesheets/layout_old/right-column.scss
+++ b/app/assets/stylesheets/layout_old/right-column.scss
@@ -78,7 +78,7 @@
     position: relative;
     display: inline-block;
     float: right;
-    max-width: 206px;
+    width: 206px;
     margin-top: 45px;
     padding-right: 0;
   }


### PR DESCRIPTION
https://trello.com/c/jnlQkoKK

See [trello comment](https://trello.com/c/jnlQkoKK/583-some-3-column-template-pages-on-www-are-appearing-with-margins-and-column-widths-not-consistent-with-the-standard#comment-59f367015d6c17c5945ab926) for explanation of issue