### PR TITLE
Removes rounded borders for flexslider in masthead.

### DIFF
--- a/app/assets/stylesheets/components/flexslider.scss
+++ b/app/assets/stylesheets/components/flexslider.scss
@@ -89,10 +89,6 @@ html[xmlns] .slides {
   background: transparent;
   border: none;
   position: relative;
-  -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
-  -o-border-radius: 5px;
-  border-radius: 5px;
   zoom: 1;
   .slides {
     zoom: 1;


### PR DESCRIPTION
Story: https://trello.com/c/Wbfhf5Ry

Just removes the rounded borders in the masthead. I looked around and didn't see anything else affected negatively.

This has already been approved but was recreated cause I accidentally branched off of development in the previous pull request: https://github.com/chapmanu/cascade-assets/pull/269.