### PR TITLE
As an OmniNav user on WWW, I want to be able to quickly access non-root umbrella categories through the off-canvas menu.

### DIFF
--- a/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
+++ b/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
@@ -112,7 +112,14 @@
     ## Is current page directory $pagePathDir under this $navDirectory? If so,
     ## we found our $navDirectory.
     #if ( $pagePath.contains($dirName) && $pagePathDir == $dirName )
-      #set ( $pageUmbrellaCategory = $umbrellaCategory )
+      ## Hasn't been set yet in a previous iteration
+      #if ( $pageUmbrellaCategory.size() == 0 )
+        #set ( $pageUmbrellaCategory = $umbrellaCategory )
+      ## If it has been set already and this is another match,
+      ## check if this new one is longer (more specific directory)
+      #elseif ( $pagePathDir.length() > $pageUmbrellaCategory[0].length() )
+        #set ( $pageUmbrellaCategory = $umbrellaCategory )
+      #end
     #end
   #end
 #end

--- a/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
+++ b/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
@@ -113,11 +113,13 @@
     ## we found our $navDirectory.
     #if ( $pagePath.contains($dirName) && $pagePathDir == $dirName )
       ## A page can enter this loop more than once if it falls under multiple umbrella categories
+      ## e.g. a page under both Campus Services and Career umbrellas
       ## First check if it hasn't been set yet
       #if ( $pageUmbrellaCategory.size() == 0 )
         #set ( $pageUmbrellaCategory = $umbrellaCategory )
       ## If it has been set, pages should use the umbrella category that's more specific
       ## This ensures the page uses the closest matching directory out of all the umbrella categories
+      ## e.g. a page under Career should use campus-services/career umbrella not campus-services
       #elseif ( $pagePathDir.length() > $pageUmbrellaCategory[0].length() )
         #set ( $pageUmbrellaCategory = $umbrellaCategory )
       #end

--- a/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
+++ b/.cascade-code/Chapman.edu/_components/omni_nav_v2/omni_nav.vtl
@@ -34,18 +34,18 @@
   [ 'pharmacy', 'CUSP', 'cusp', '/pharmacy/' ],
   [ 'law', 'FOWLER SCHOOL OF LAW', 'fowler', '/law/' ],
   [ 'scst', 'SCHMID COLLEGE', 'schmid', '/scst/' ],
+  [ 'communication', 'SCHOOL OF COMM', 'soc', '/communication/' ],
   [ 'about', 'About', 'default', '/' ],
   [ 'academics', 'Academics', 'default', '/' ],
   [ 'admission', 'Admission', 'default', '/' ],
   [ 'alumni', 'Alumni', 'default', '/' ],
   [ 'campus-services', 'Campus Services', 'default', '/' ],
+  [ 'campus-services/career-development', 'Career', 'default', '/' ],
   [ 'faculty-staff', 'Faculty and Staff', 'default', '/' ],
   [ 'families', 'Families', 'default', '/' ],
   [ 'research', 'Research', 'default', '/' ],
   [ 'students', 'Students', 'default', '/' ],
-  [ 'support-chapman', 'Support Chapman', 'default', '/' ],
-  [ 'communication', 'SCHOOL OF COMM', 'soc', '/communication/' ],
-  [ 'campus-services/career-development', 'Career', 'default', '/' ]
+  [ 'support-chapman', 'Support Chapman', 'default', '/' ]
 ])
 
 ##
@@ -112,11 +112,12 @@
     ## Is current page directory $pagePathDir under this $navDirectory? If so,
     ## we found our $navDirectory.
     #if ( $pagePath.contains($dirName) && $pagePathDir == $dirName )
-      ## Hasn't been set yet in a previous iteration
+      ## A page can enter this loop more than once if it falls under multiple umbrella categories
+      ## First check if it hasn't been set yet
       #if ( $pageUmbrellaCategory.size() == 0 )
         #set ( $pageUmbrellaCategory = $umbrellaCategory )
-      ## If it has been set already and this is another match,
-      ## check if this new one is longer (more specific directory)
+      ## If it has been set, pages should use the umbrella category that's more specific
+      ## This ensures the page uses the closest matching directory out of all the umbrella categories
       #elseif ( $pagePathDir.length() > $pageUmbrellaCategory[0].length() )
         #set ( $pageUmbrellaCategory = $umbrellaCategory )
       #end


### PR DESCRIPTION
Story: https://trello.com/c/H530g9YQ

These changes will let us use any kind of nested umbrella category, if there are multiple under the same root folder, listed in any order under $umbrellaCategories