### PR TITLE
Fix to script for weather feed to get current temp

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/blocks/html/global_footer.html
+++ b/.cascade-code/Chapman.edu/_cascade/blocks/html/global_footer.html
@@ -78,7 +78,7 @@
       <div class="weather">
         <!-- Why are these values hardcoded? Are they dynamically updated after page load? -->
         <a class="weather-icon"
-           href="http://forecast.chapman.edu/"
+           href="https://forecast.chapman.edu/"
            rel="noopener noreferrer"
            target="_blank">
           <img alt="Schmid College of Science California Weather Forecast Site"

--- a/app/assets/javascripts/cascade/weather.js
+++ b/app/assets/javascripts/cascade/weather.js
@@ -1,19 +1,16 @@
 $(function () {
-
-	/* Populate weather from json feed; default on page is 65 until modified by this routine
-    ------------------------------------------------------------------------------------------------*/
-	//sample data: {"weather":{"icon_path":"\/images\/icons\/weather\/2cloud_norain.png","temp_f":"66","temp_c":"19"}}
-	$.getJSON("https://forecast.chapman.edu/chapman/banner-json.php?callback=orange", function (data) {	
-
-        var iconPath = data.weather.icon_path,
-            tempF = data.weather.temp_f,
-            tempC = data.weather.temp_c,
-            url = "//www.chapman.edu",
-            $weather = $(".weather");
-
-        $weather.find("img").attr("src", url + iconPath);
-        $weather.find(".temp .f").html(tempF + "&deg; F");
-        $weather.find(".temp .c").html(tempC + "&deg; C");
-    });
-
+  /* Populate weather from json feed; default on page is 65 until modified by this routine
+  ------------------------------------------------------------------------------------------------*/
+  //sample data: {"weather":{"icon_path":"\/images\/icons\/weather\/2cloud_norain.png","temp_f":"66","temp_c":"19"}}
+  $.getJSON("https://forecast.chapman.edu/chapman/banner-json.php?callback=orange", function (data) {	
+    var iconPath = data.weather.icon_path,
+      tempF = data.weather.temp_f,
+      tempC = data.weather.temp_c,
+      url = "//www.chapman.edu",
+      $weather = $(".weather");
+    //find weather class in html and substitute placeholders with current temp
+    $weather.find("img").attr("src", url + iconPath);
+    $weather.find(".temp .f").html(tempF + "&deg; F");
+    $weather.find(".temp .c").html(tempC + "&deg; C");
+  });
 });

--- a/app/assets/javascripts/cascade/weather.js
+++ b/app/assets/javascripts/cascade/weather.js
@@ -1,10 +1,9 @@
 $(function () {
 
-	/* Populate weather from jsonp feed
+	/* Populate weather from json feed; default on page is 65 until modified by this routine
     ------------------------------------------------------------------------------------------------*/
-
-    $.getJSON("//forecast.chapman.edu/chapman/banner-json.php?callback=?", function (data) {
-
+	//sample data: {"weather":{"icon_path":"\/images\/icons\/weather\/2cloud_norain.png","temp_f":"66","temp_c":"19"}}
+	$.getJSON("https://forecast.chapman.edu/chapman/banner-json.php?callback=orange", function (data) {	
 
         var iconPath = data.weather.icon_path,
             tempF = data.weather.temp_f,

--- a/app/views/_cascade/blocks/html/_footer.html
+++ b/app/views/_cascade/blocks/html/_footer.html
@@ -58,7 +58,7 @@
     <span class="link-container-after">&#160;</span>
     <div class="footer-info footer-section">
       <div class="weather">
-        <a class="weather-icon" href="http://forecast.chapman.edu/" target="_blank">
+        <a class="weather-icon" href="https://forecast.chapman.edu/" target="_blank"> 
           <img alt="Schmid College of Science California Weather Forecast Site" src="<%= image_path 'placeholder/0cloud.png' %>" />
         </a>
         <div class="temp">

--- a/app/views/_cascade/blocks/html/_law_footer.html
+++ b/app/views/_cascade/blocks/html/_law_footer.html
@@ -88,7 +88,7 @@
     <span class="link-container-after">&#160;</span>
     <div class="footer-info footer-section">
       <div class="weather">
-        <a class="weather-icon" href="http://forecast.chapman.edu/" target="_blank">
+        <a class="weather-icon" href="https://forecast.chapman.edu/" target="_blank">
           <img alt="Schmid College of Science California Weather Forecast Site" src="<%= image_path 'placeholder/0cloud.png' %>" />
         </a>
         <div class="temp">


### PR DESCRIPTION
In weather.js  the url to json feed of current temperature was using callback=? as url param, and now we need to use callback=orange per Nikos H. in Schmid College; also fixing links in footer blocks to link to forecast.chapman.edu with https as they installed an SSL certificate awhile back