### PR TITLE
Fix funnels-1up widget on mobile

### DIFF
--- a/app/assets/stylesheets/widgets/primary_column/regions.scss
+++ b/app/assets/stylesheets/widgets/primary_column/regions.scss
@@ -38,6 +38,10 @@ div.four-col-float {
     -moz-box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.2);
     box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.2);
     float: left;
+    
+    @include bp(mx) {
+      float: none;
+    }
   }
 
   .region li {


### PR DESCRIPTION
demonstrated fix: https://dev-www.chapman.edu/campus-life/index.aspx

At max-width: 767px breakpoint, image will lose float and text will drop below. 