### PR TITLE
News instead of blogs feed

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col
@@ -27,7 +27,7 @@
   <ul class="newsEventsContent">
     ## FIXME: This should be wrapped in a no-display li tag. But doing so will break
     ## tab functionality.
-    <a class="no-js-link" href="https://blogs.chapman.edu/news-and-stories/" title="View All News Stories">View All News »</a>
+    <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
     <a class="no-js-link" href="https://events.chapman.edu" title="View All Event Listings">View All Events »</a>
 
     ## Featured Tab Content

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content
@@ -27,7 +27,7 @@
   <ul class="newsEventsContent">
     ## FIXME: This should be wrapped in a no-display li tag. But doing so will break
     ## tab functionality.
-    <a class="no-js-link" href="https://blogs.chapman.edu/news-and-stories/" title="View All News Stories">View All News »</a>
+    <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
     <a class="no-js-link" href="https://events.chapman.edu" title="View All Event Listings">View All Events »</a>
 
     #buildFeaturedTabContent()

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -45,6 +45,7 @@ $(function () {
   /* Populate news from Wordpress RSS feed (converted to JSON with YQL)
   ------------------------------------------------------------------------------------------------*/
   if ($(".news").length) {
+    //default is NewsAndStories:
     var newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories",
       newsYqlUrl = function () {
         return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
@@ -90,10 +91,10 @@ $(function () {
         newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
         $(".allNews").attr("href", "http://blogs.chapman.edu/law");
         break;
-      case "News and Stories":
-        newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories";
-        $(".allNews").attr("href", "https://news.chapman.edu");
-        break;
+      //case "News and Stories":
+      //  newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories";
+      //  $(".allNews").attr("href", "https://news.chapman.edu");
+      //   break;
       case "Pharmacy":
         newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
         $(".allNews").attr("href", "http://blogs.chapman.edu/pharmacy");

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -45,7 +45,7 @@ $(function () {
   /* Populate news from Wordpress RSS feed (converted to JSON with YQL)
   ------------------------------------------------------------------------------------------------*/
   if ($(".news").length) {
-    var newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories",
+    var newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories",
       newsYqlUrl = function () {
         return ("//query.yahooapis.com/v1/public/yql?q=select%20*%20from%20rss(3)%20where%20url%3D'" + newsFeedUrl + "'&format=json&diagnostics=true&callback=?")
       },
@@ -91,8 +91,8 @@ $(function () {
         $(".allNews").attr("href", "http://blogs.chapman.edu/law");
         break;
       case "News and Stories":
-        newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories";
-        $(".allNews").attr("href", "http://blogs.chapman.edu/news-and-stories");
+        newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories";
+        $(".allNews").attr("href", "https://news.chapman.edu");
         break;
       case "Pharmacy":
         newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
@@ -119,7 +119,7 @@ $(function () {
         $(".allNews").attr("href", "http://blogs.chapman.edu/wilkinson");
         break;
       default:
-        $(".allNews").attr("href", "http://blogs.chapman.edu/news-and-stories");
+        $(".allNews").attr("href", "https://news.chapman.edu");
         break;
     }
 

--- a/app/assets/javascripts/cascade/level/news-events.js
+++ b/app/assets/javascripts/cascade/level/news-events.js
@@ -91,10 +91,6 @@ $(function () {
         newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsLaw";
         $(".allNews").attr("href", "http://blogs.chapman.edu/law");
         break;
-      //case "News and Stories":
-      //  newsFeedUrl = "https://www.chapman.edu/getFeed.ashx?name=newsNewsAndStories";
-      //  $(".allNews").attr("href", "https://news.chapman.edu");
-      //   break;
       case "Pharmacy":
         newsFeedUrl = "http://www.chapman.edu/getFeed.ashx?name=newsPharmacy";
         $(".allNews").attr("href", "http://blogs.chapman.edu/pharmacy");

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -710,7 +710,7 @@
         </group>
         <group identifier="news-events-options" label="Featured / News / Events Feeds">
             <asset identifier="feature" label="Feature" type="page"/>
-            <text default="Default" identifier="newsFeed" label="News Feed" type="dropdown">
+            <text default="Default" help-text="Default is stories from Newsroom maintained by Marketing Dept at Chapman" identifier="newsFeed" label="News Feed" type="dropdown">
                 <dropdown-item value="Default"/>
                 <dropdown-item value="Admissions"/>
                 <dropdown-item value="ASBE"/>
@@ -721,7 +721,6 @@
                 <dropdown-item value="Education"/>
                 <dropdown-item value="Information Systems"/>
                 <dropdown-item value="Law"/>
-                <dropdown-item value="News and Stories"/>
                 <dropdown-item value="Pharmacy"/>
                 <dropdown-item value="Schmid"/>
                 <dropdown-item value="SOC"/>
@@ -729,7 +728,7 @@
                 <dropdown-item value="Thompson Policy Institute"/>
                 <dropdown-item value="Wilkinson"/>
             </text>
-            <text default="Default" identifier="eventsFeed" label="Events Feed" type="dropdown">
+            <text default="Default" help-text="Default is today's events on events.chapman.edu" identifier="eventsFeed" label="Events Feed" type="dropdown">
                 <dropdown-item value="Default"/>
                 <dropdown-item value="ASBE"/>
                 <dropdown-item value="CDC"/>

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -559,6 +559,8 @@
                     <dropdown-item value="SCST-CBFS"/>
                     <dropdown-item value="SCST-LES"/>
                     <dropdown-item value="SCST-MPC"/>
+                    <dropdown-item value="PHRM-BPS"/>
+                    <dropdown-item value="PHRM-PP"/>
                 </text>
                 <text default="Yes" identifier="photo" label="Show Photo" required="true" type="radiobutton">
                     <radio-item value="Yes"/>

--- a/app/data_definitions/from_cascade/two_column.xml
+++ b/app/data_definitions/from_cascade/two_column.xml
@@ -643,7 +643,7 @@
         </group>
         <group identifier="news-events-options" label="Featured / News / Events Feeds">
             <asset identifier="feature" label="Feature" type="page"/>
-            <text default="Default" identifier="newsFeed" label="News Feed" type="dropdown">
+            <text default="Default" help-text="Default is stories from Newsroom maintained by Marketing Dept at Chapman" identifier="newsFeed" label="News Feed" type="dropdown">
                 <dropdown-item value="Default"/>
                 <dropdown-item value="Admissions"/>
                 <dropdown-item value="ASBE"/>
@@ -654,7 +654,6 @@
                 <dropdown-item value="Education"/>
                 <dropdown-item value="Information Systems"/>
                 <dropdown-item value="Law"/>
-                <dropdown-item value="News and Stories"/>
                 <dropdown-item value="Pharmacy"/>
                 <dropdown-item value="Schmid"/>
                 <dropdown-item value="SOC"/>
@@ -662,7 +661,7 @@
                 <dropdown-item value="Thompson Policy Institute"/>
                 <dropdown-item value="Wilkinson"/>
             </text>
-            <text default="Default" identifier="eventsFeed" label="Events Feed" type="dropdown">
+            <text default="Default" help-text="Default is today's events on events.chapman.edu" identifier="eventsFeed" label="Events Feed" type="dropdown">
                 <dropdown-item value="Default"/>
                 <dropdown-item value="ASBE"/>
                 <dropdown-item value="CDC"/>

--- a/app/data_definitions/from_cascade/two_column.xml
+++ b/app/data_definitions/from_cascade/two_column.xml
@@ -606,6 +606,8 @@
                     <dropdown-item value="SCST-CBFS"/>
                     <dropdown-item value="SCST-LES"/>
                     <dropdown-item value="SCST-MPC"/>
+                    <dropdown-item value="PHRM-BPS"/>
+                    <dropdown-item value="PHRM-PP"/>
                 </text>
                 <text default="Yes" identifier="photo" label="Show Photo" required="true" type="radiobutton">
                     <radio-item value="Yes"/>

--- a/app/views/widgets/left_column/_news_event_left_col.html
+++ b/app/views/widgets/left_column/_news_event_left_col.html
@@ -11,7 +11,7 @@
     <li tabindex="0" class="">Events</li>
   </ul>
   <ul class="newsEventsContent">
-    <a class="no-js-link" href="https://blogs.chapman.edu/news-and-stories/" title="View All News Stories">View All News »</a>
+    <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
     <a class="no-js-link" href="https://events.chapman.edu" title="View All Event Listings">View All Events »</a>
     <li class="active">
       <div class="featured">
@@ -88,7 +88,7 @@
           <div class="title">
             <a href="https://blogs.chapman.edu/happenings/2017/09/26/sylvia-mendez-segregation-still-exists-public-schools/">Sylvia Mendez: De facto segregation still exists in public schools</a>
           </div>
-        </div><a class="allNews" href="http://blogs.chapman.edu/news-and-stories">View all News »</a>
+        </div><a class="allNews" href="https://news.chapman.edu">View all News »</a>
       </div>
     </li>
     <li class="">

--- a/app/views/widgets/left_column/_news_events_1.html
+++ b/app/views/widgets/left_column/_news_events_1.html
@@ -11,7 +11,7 @@
     <li tabindex="0" class="">Events</li>
   </ul>
   <ul class="newsEventsContent">
-    <a class="no-js-link" href="https://blogs.chapman.edu/news-and-stories/" title="View All News Stories">View All News »</a>
+    <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
     <a class="no-js-link" href="https://events.chapman.edu" title="View All Event Listings">View All Events »</a>
     <li class="active">
       <div class="featured">
@@ -88,7 +88,7 @@
           <div class="title">
             <a href="https://blogs.chapman.edu/happenings/2017/09/26/sylvia-mendez-segregation-still-exists-public-schools/">Sylvia Mendez: De facto segregation still exists in public schools</a>
           </div>
-        </div><a class="allNews" href="http://blogs.chapman.edu/news-and-stories">View all News »</a>
+        </div><a class="allNews" href="https://news.chapman.edu">View all News »</a>
       </div>
     </li>
     <li class="">

--- a/app/views/widgets/primary_content/_featured_news_events_feed_1.html
+++ b/app/views/widgets/primary_content/_featured_news_events_feed_1.html
@@ -5,7 +5,7 @@
         <li tabindex="0" >Events</li>
     </ul>
   <ul class="newsEventsContent">
-    <a class="no-js-link" href="https://blogs.chapman.edu/news-and-stories/" title="View All News Stories">View All News »</a>
+    <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
     <a class="no-js-link" href="https://events.chapman.edu/" title="View All Event Listings">View All Events »</a>
     <li class="active">
         <div class="featured">
@@ -78,7 +78,7 @@
           <!--<p class="copy ellipsis multiline"></p>-->
           <!--<a class="readMore">Read More »</a>-->
         </div>
-        <a class="allNews" href="http://blogs.chapman.edu/news-and-stories">View all News »</a>
+        <a class="allNews" href="https://news.chapman.edu">View all News »</a>
       </div>
     </li>
     <li>


### PR DESCRIPTION
for the Default news feed and default link for View All News in the News and Events widget (2 and 3 Column Modular templates), change from blogs.chapman.edu/news-and-stories to news.chapman.edu