### PR TITLE
Omni nav link fix for Financial Aid Calculator

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -633,7 +633,7 @@
           <li><a href="site://Chapman.edu/admission/graduate/index">Graduate Admission</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/applynow">Graduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/afford">Affordability</a></li>
-          <li><a href="site://Chapman.edu/students/tuition-and-aid/financial-aid/undergraduate/net-cost-calculator/index">Financial Aid Calculator</a></li>
+          <li><a href="site://Chapman.edu/students/tuition-and-aid/financial-aid/net-cost-calculator/index">Financial Aid Calculator</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/visit">Campus Tours</a></li>
         </ul>
       </li>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -633,7 +633,7 @@
           <li><a href="site://Chapman.edu/admission/graduate/index">Graduate Admission</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/applynow">Graduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/afford">Affordability</a></li>
-          <li><a href="site://Chapman.edu/students/tuition-and-aid/financial-aid/net-cost-calculator/index">Financial Aid Calculator</a></li>
+          <li><a href="site://Chapman.edu/students/tuition-and-aid/financial-aid/undergraduate/net-cost-calculator/index">Financial Aid Calculator</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/visit">Campus Tours</a></li>
         </ul>
       </li>


### PR DESCRIPTION
the page for Financial Aid Calculator was moved so just fixing link in omniNav to reflect. Already made changes in live site to this format on the day the page was moved. This is to sync github to same changes.