### PR TITLE
add escapeTool.xml function to child A tag urls

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/level/left_nav.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/level/left_nav.vtl
@@ -88,7 +88,7 @@
     
     ## Output
     <li class="${liClass}">
-        <a href="${siblingPage.link}">$siblingPageTitle
+        <a href="${_EscapeTool.xml($siblingPage.link)}">$siblingPageTitle
         #if ( $siblingPage.assetType == 'symlink' )
          <span class="fas fa-external-link-alt"></span>
         #end
@@ -172,7 +172,7 @@
     
     ## Output
     <li>
-        <a href="${childLink}">
+        <a href="${_EscapeTool.xml($childLink)}">
             <span class="bullet">» </span>
             $childTitle 
             #if ( $child.assetType == 'symlink' )

--- a/.cascade-code/Chapman.edu/_cascade/formats/level/left_nav_no_siblings.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/level/left_nav_no_siblings.vtl
@@ -26,7 +26,7 @@
     <div class="leftTitle">
         <ul>
             <li class="title">
-            <a href="${currentPage.link}" target="_top">
+            <a href="${_EscapeTool.xml($currentPage.link)}" target="_top">
                 ${_EscapeTool.xml($currentPage.label)}
             </a>
             </li>
@@ -40,7 +40,7 @@
     <div class="leftTitle">
         <ul>
             <li class="title">
-            <a href="${currentPage.link}" target="_top">
+            <a href="${_EscapeTool.xml($currentPage.link)}" target="_top">
                 ${_EscapeTool.xml($currentPage.label)}
             </a>
             </li>
@@ -86,7 +86,7 @@
     
     ## Output
     <li class="${liClass}">
-        <a href="${childPage.link}">$childPageTitle
+        <a href="${_EscapeTool.xml($childPage.link)}">$childPageTitle
         #if ( $childPage.assetType == 'symlink' )
          <span class="fas fa-external-link-alt"></span>
         #end
@@ -172,7 +172,7 @@
     
             ## Output
             <li>
-                <a href="$grandchildLink" title="$grandchildTitle">
+                <a href="${_EscapeTool.xml($grandchildLink)}">
                     <span class="bullet">» </span>
                     $grandchildTitle
                     #if ( $grandchild.assetType == 'symlink' )


### PR DESCRIPTION
add escapeTool.xml to several child or grandchild links in the 2 velocity formats that produce the Lefthand menus so symbolic links that have special chars in the url won't produce errors in the xml parsing