### PR TITLE
resolves remaining  'Content not included in landmarks' alerts

### DIFF
--- a/app/assets/javascripts/cascade/accessibility__landmarks.js
+++ b/app/assets/javascripts/cascade/accessibility__landmarks.js
@@ -1,0 +1,7 @@
+function nsLandmark() {
+  $('noscript').wrap('<section role="no script">')
+}
+
+$(window).load(function () {
+  nsLandmark();
+});

--- a/app/assets/javascripts/master.js
+++ b/app/assets/javascripts/master.js
@@ -9,6 +9,7 @@
 //= require_tree ./regions
 //= require_tree ./omni_nav
 
+//= require cascade/accessibility__landmarks.js
 //= require cascade/analytics
 //= require cascade/carousel
 //= require cascade/collapsed-nav


### PR DESCRIPTION
(followup to #432)

This is a novel approach that appeases Siteimprove's remaining Info and `Relationships 1.3.1 > Content not included in landmarks`. Since I'm using the extension to test, I'm unsure if this will work from Siteimprove's dashboard, as it may run before the JS fires ([like the iFrame title issue, which Wave doesn't flag ](https://trello.com/c/zYKQAVQq)). 

You can preview it at https://dev-www.chapman.edu/test-section/nick-test/index1.aspx 