### PR TITLE
Resolves flash of disabled JS alert

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/blocks/html/no_script.html
+++ b/.cascade-code/Chapman.edu/_cascade/blocks/html/no_script.html
@@ -1,9 +1,13 @@
-<section aria-label="For browsers without Javascript">
-  <div class="noscript">
-    <p>
+<system-xml>
+	<section aria-label="For browsers without Javascript">
+		<noscript>
+			<div class="noscript">
+				<p>
       Some of the content on this website requires JavaScript to be enabled in your web browser to function as
       intended. This includes, but is not limited to: navigation, video, image galleries, etc. While the website is
       still usable without JavaScript, it should be enabled to enjoy the full interactive experience.
     </p>
-  </div>
-</section>
+			</div>
+		</noscript>
+	</section>
+</system-xml>

--- a/.cascade-code/Chapman.edu/_cascade/blocks/html/no_script.html
+++ b/.cascade-code/Chapman.edu/_cascade/blocks/html/no_script.html
@@ -6,7 +6,7 @@
       Some of the content on this website requires JavaScript to be enabled in your web browser to function as
       intended. This includes, but is not limited to: navigation, video, image galleries, etc. While the website is
       still usable without JavaScript, it should be enabled to enjoy the full interactive experience.
-    </p>
+    				</p>
 			</div>
 		</noscript>
 	</section>


### PR DESCRIPTION
In #431, deferring master JS for improved load times introduced a poor UX issue wherein the "Some of the content on this website requires JavaScript to be enabled" alert flashes for a split second before the page loads. This is related to `<div class="noscript">` vs `<noscript>`. This PR resolves the issue. 

Demo: https://dev-www.chapman.edu/academics/index.aspx
