### PR TITLE
addresses Siteimprove 2.4.4

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -431,9 +431,22 @@
         <a class="icon $overviewIconClass" href="site://Chapman.edu/$overviewLink">$parentPage Overview</a>
       </li>
       #foreach( $dropdownLink in $dropdownLinks )
-        <li>
+        #set ($defaultLinkName = "${_EscapeTool.xml( $dropdownLink.text )}")
+          <li>
           #if($dropdownLink.link.toString().contains("http"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link">
+          #elseif($dropdownLink.link.toString().contains("about/connect/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect">
+          #elseif($dropdownLink.link.toString().contains("alumni/events/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni events">
+          #elseif($dropdownLink.link.toString().contains("alumni/get-involved/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni - get involved">
+          #elseif($dropdownLink.link.toString().contains("support-chapman/get-involved"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman - get involved">
+          #elseif($dropdownLink.link.toString().contains("about/connect/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect with Chapman">
+          #elseif($dropdownLink.link.toString().contains("discover"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="$defaultLinkName">
           #else
             <a class="icon $dropdownLink.iconClass" href="site://Chapman.edu/$dropdownLink.link">          
           #end
@@ -465,7 +478,7 @@
         <div class="utility-dropdown dropdown">
           <ul>
             <li><a href="site://Chapman.edu/future-students/index">Prospective Students</a></li>
-            <li><a href="site://Chapman.edu/students/index">Current Students</a></li>
+            <li><a href="site://Chapman.edu/students/index" >Current Students</a></li>
             <li><a href="site://Chapman.edu/alumni/index">Alumni</a></li>
             <li><a href="site://Chapman.edu/faculty-staff/index">Faculty &amp; Staff</a></li>
             <li><a href="site://Chapman.edu/families/index">Parents &amp; Families</a></li>
@@ -475,10 +488,10 @@
       <li class="utility-cell"><a href="site://Chapman.edu/academics/degrees-and-programs">Degrees &amp; Programs</a></li>
       <li class="utility-cell"><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
       <li class="utility-cell"><a href="site://Chapman.edu/directory/index">All Directories</a></li>
-      <li class="utility-cell"><a href="https://news.chapman.edu/">News</a></li>
-      <li class="utility-cell"><a href="https://events.chapman.edu/">Events</a></li>
+      <li class="utility-cell"><a href="https://news.chapman.edu/" aria-label="Chapman Newsroom">News</a></li>
+      <li class="utility-cell"><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
       <li class="utility-cell utility-has-dropdown">
-        <a href="#">Social</a>
+        <a href="#" role="listbox" aria-label="Social listbox">Social</a>
         <div class="utility-dropdown social-dropdown dropdown">
           <ul>
             <li>
@@ -632,7 +645,7 @@
         <ul>
           <li><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
           <li><a href="site://Chapman.edu/about/visit/index">Visit Chapman</a></li>
-          <li><a href="site://Chapman.edu/discover/index">Discover Chapman</a></li>
+          <li><a href="site://Chapman.edu/discover/index" aria-label="Discover Chapman">Discover Chapman</a></li>
           <li><a href="site://Chapman.edu/about/facts-and-rankings/index">Facts &amp; Rankings</a></li>
           <li><a href="site://Chapman.edu/about/our-family/leadership/index">Leadership</a></li>
           <li><a href="site://Chapman.edu/campus-services/index">Campus Services</a></li>
@@ -669,8 +682,8 @@
         <a href="site://Chapman.edu/alumni/index">Alumni</a>
         #buildToggleIcon("Alumni")
         <ul>
-          <li><a href="site://Chapman.edu/alumni/events/index">Events</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/events/index" aria-label="Alumni Events">Events</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
           <li><a href="site://Chapman.edu/campus-services/career-professional-development/index">Career Support</a></li>
         </ul>
       </li>
@@ -681,7 +694,7 @@
         <ul>
           <li><a href="http://www.chapmanathletics.com/landing/index">Athletics</a></li>
           <li><a href="site://Chapman.edu/diversity/index">Diversity &amp; Inclusion</a></li>
-          <li><a href="https://events.chapman.edu/">Events</a></li>
+          <li><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
           <li><a href="site://Chapman.edu/campus-life/fish-interfaith-center/index">Fish Interfaith Center</a></li>
           <li><a href="site://Chapman.edu/students/health-and-safety/index">Health &amp; Safety</a></li>
           <li><a href="site://Chapman.edu/students/services/housing-and-residence/index">Residence Life</a></li>
@@ -705,9 +718,9 @@
         #buildToggleIcon("Support")
         <ul>
           <li><a href="site://Chapman.edu/support-chapman/contact-us">Contact Development</a></li>
-          <li><a href="site://Chapman.edu/support-chapman/get-involved">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support - involvement opportunities">Get Involved</a></li>
           <li><a href="site://Chapman.edu/support-chapman/ways-to-give/areas-to-support">Areas to Support</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni Involvement</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni - get involved</a></li>
         </ul>
       </li>
     </ul>
@@ -728,9 +741,9 @@
         <li><a href="site://Chapman.edu/academics/degrees-and-programs">Degrees &amp; Programs</a></li>
         <li><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
         <li><a href="site://Chapman.edu/directory/index">All Directories</a></li>
-        <li><a href="https://news.chapman.edu/">News</a></li>
-        <li><a href="https://events.chapman.edu/">Events</a></li>
-        <li><a href="https://social.chapman.edu/">Social</a></li>
+        <li><a href="https://news.chapman.edu/" aria-label="Chapman Newsroom">News</a></li>
+        <li><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
+        <li><a href="https://social.chapman.edu/" aria-label="Chapman Social Hub">Social</a></li>
       </ul>
     </div>
   </div>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -720,7 +720,7 @@
           <li><a href="site://Chapman.edu/support-chapman/contact-us">Contact Development</a></li>
           <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support - involvement opportunities">Get Involved</a></li>
           <li><a href="site://Chapman.edu/support-chapman/ways-to-give/areas-to-support">Areas to Support</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni - get involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
https://trello.com/c/bNrtZRm5

Address Siteimproves "Link text used for multiple different destinations". 

Some sections use the same text to describe different links, eg `"Alumni" > "Get Involved" (https://dev-www.chapman.edu/alumni/get-involved/index.aspx)` and `"Support" > "Get Involved" (https://dev-www.chapman.edu/support-chapman/get-involved.aspx)` .  I've applied aria-labels where appropriate.

You can demo with the Siteimprove extension at https://dev-www.chapman.edu/test-section/nick-test/index1.aspx and compare against the former issues at https://my2.siteimprove.com/Inspector/10993/Accessibility/Page?pageId=31903631364&impmd=0D6974F8A4BBF3C0E325AAA2E369A7D2#/Criterion/2.4.4/Check/39

Note that in Siteimprove 2.4.4, it will now ask "Does the "aria-label" accurately describe the link?" ... "This warning will appear for all of your 'aria-label' on links since a manual review is needed."
