### PR TITLE
Accessibility Siteimprove 2.4.4

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
+++ b/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
@@ -65,20 +65,20 @@
             </ul>
 
             <div class="actions">
-                <a class="button white smc-cta" data-cta-id="homepage-ug-adm" data--100-bottom="opacity:1" data-bottom="opacity:0" href="https://www.chapman.edu/discover/index.html">Discover Chapman</a>
+                <a class="button white smc-cta" data-cta-id="homepage-ug-adm" data--100-bottom="opacity:1" data-bottom="opacity:0" href="site://Chapman.edu/discover/index">Discover Chapman</a>
                 
                 ### popup form not used: <a class="button red request admissionCTA_start" data--100-bottom="opacity:1" data-bottom="opacity:0" href="javascript:void();">Request Information</a>
                 #if ($leftButtonTrackID != "")
-                    <a class="button white smc-cta" data-cta-id="$leftButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink">$leftButtonLabel</a>
+                    <a class="button white smc-cta" data-cta-id="$leftButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink" aria-label="$leftButtonLabel">$leftButtonLabel</a>
                 #else
-                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink">$leftButtonLabel</a>
+                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink" aria-label="$leftButtonLabel">$leftButtonLabel</a>
                 #end
                 #if ($rightButtonTrackID != "")
-                    <a class="button white smc-cta" data-cta-id="$rightButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$rightButtonLink">$rightButtonLabel</a>
+                    <a class="button white smc-cta" data-cta-id="$rightButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href='$rightButtonLink' aria-label="$rightButtonLabel">$rightButtonLabel</a>
                 #else
-                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$rightButtonLink">$rightButtonLabel</a>
+                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$rightButtonLink" aria-label='{$rightButtonLabel}'>$rightButtonLabel</a>
                 #end
 
             </div>
         </div>
-</section>
+    </section>

--- a/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
+++ b/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
@@ -69,7 +69,7 @@
                 
                 ### popup form not used: <a class="button red request admissionCTA_start" data--100-bottom="opacity:1" data-bottom="opacity:0" href="javascript:void();">Request Information</a>
                 #if ($leftButtonTrackID != "")
-                    <a class="button white smc-cta" data-cta-id="$leftButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink" aria-label="$leftButtonLabel">$leftButtonLabel</a>
+                    <a class="button white smc-cta" data-cta-id="$leftButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink">$leftButtonLabel</a>
                 #else
                     <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink">$leftButtonLabel</a>
                 #end
@@ -81,4 +81,4 @@
 
             </div>
         </div>
-    </section>
+  </section>

--- a/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
+++ b/.cascade-code/Chapman.edu/_cascade/formats/Homepage UG Admission Section
@@ -71,12 +71,12 @@
                 #if ($leftButtonTrackID != "")
                     <a class="button white smc-cta" data-cta-id="$leftButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink" aria-label="$leftButtonLabel">$leftButtonLabel</a>
                 #else
-                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink" aria-label="$leftButtonLabel">$leftButtonLabel</a>
+                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$leftButtonLink">$leftButtonLabel</a>
                 #end
                 #if ($rightButtonTrackID != "")
-                    <a class="button white smc-cta" data-cta-id="$rightButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href='$rightButtonLink' aria-label="$rightButtonLabel">$rightButtonLabel</a>
+                    <a class="button white smc-cta" data-cta-id="$rightButtonTrackID" data--100-bottom="opacity:1" data-bottom="opacity:0" href='$rightButtonLink'>$rightButtonLabel</a>
                 #else
-                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$rightButtonLink" aria-label='{$rightButtonLabel}'>$rightButtonLabel</a>
+                    <a class="button white" data--100-bottom="opacity:1" data-bottom="opacity:0" href="$rightButtonLink">$rightButtonLabel</a>
                 #end
 
             </div>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -435,16 +435,16 @@
           <li>
           #if($dropdownLink.link.toString().contains("http"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link">
-          #elseif($dropdownLink.link.toString().contains("about/connect/"))
-            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect">
-          #elseif($dropdownLink.link.toString().contains("alumni/events/"))
+          #elseif($dropdownLink.link.toString().contains("alumni/events/index"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni events">
-          #elseif($dropdownLink.link.toString().contains("alumni/get-involved/"))
-            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni - get involved">
+          #elseif($dropdownLink.link.toString().contains("alumni/get-involved/index"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni: Get Involved">
           #elseif($dropdownLink.link.toString().contains("support-chapman/get-involved"))
-            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman - get involved">
-          #elseif($dropdownLink.link.toString().contains("about/connect/"))
-            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect with Chapman">
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman: Get Involved">
+          #elseif($dropdownLink.link.toString().contains("about/connect/index"))
+            <a class="icon $dropdownLink.iconClass" href="https://www.chapman.edu/about/connect/index.aspx" aria-label="Connect with Chapman">
+          #elseif($dropdownLink.link.toString().contains("undergraduate/applynow"))
+            <a class="icon $dropdownLink.iconClass" href="https://www.chapman.edu/admission/undergraduate/applynow">
           #elseif($dropdownLink.link.toString().contains("discover"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="$defaultLinkName">
           #else
@@ -649,7 +649,7 @@
           <li><a href="site://Chapman.edu/about/facts-and-rankings/index">Facts &amp; Rankings</a></li>
           <li><a href="site://Chapman.edu/about/our-family/leadership/index">Leadership</a></li>
           <li><a href="site://Chapman.edu/campus-services/index">Campus Services</a></li>
-          <li><a href="site://Chapman.edu/about/connect">Connect</a></li>
+          <li><a href="https://dev-www.chapman.edu/about/connect/index.aspx">Connect</a></li>
         </ul>
       </li>
       <li>
@@ -670,7 +670,7 @@
         #buildToggleIcon("Admission")
         <ul>
           <li><a href="site://Chapman.edu/admission/undergraduate/index">Undergraduate Admission</a></li>
-          <li><a href="site://Chapman.edu/admission/undergraduate/applynow">Undergraduate Application</a></li>
+          <li><a href="https://www.chapman.edu/admission/undergraduate/applynow">Undergraduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/index">Graduate Admission</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/applynow">Graduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/afford">Affordability</a></li>
@@ -683,7 +683,7 @@
         #buildToggleIcon("Alumni")
         <ul>
           <li><a href="site://Chapman.edu/alumni/events/index" aria-label="Alumni Events">Events</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni: Get Involved">Get Involved</a></li>
           <li><a href="site://Chapman.edu/campus-services/career-professional-development/index">Career Support</a></li>
         </ul>
       </li>
@@ -718,9 +718,9 @@
         #buildToggleIcon("Support")
         <ul>
           <li><a href="site://Chapman.edu/support-chapman/contact-us">Contact Development</a></li>
-          <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support - involvement opportunities">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support: Involvement Opportunities">Get Involved</a></li>
           <li><a href="site://Chapman.edu/support-chapman/ways-to-give/areas-to-support">Areas to Support</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni: Get Involved">Get Involved</a></li>
         </ul>
       </li>
     </ul>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -442,7 +442,7 @@
           #elseif($dropdownLink.link.toString().contains("support-chapman/get-involved"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman: Get Involved">
           #elseif($dropdownLink.link.toString().contains("about/connect/index"))
-            <a class="icon $dropdownLink.iconClass" href="/about/connect/index" aria-label="Connect with Chapman">
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect with Chapman">
           #else
             <a class="icon $dropdownLink.iconClass" href="site://Chapman.edu/$dropdownLink.link">          
           #end

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -443,10 +443,6 @@
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman: Get Involved">
           #elseif($dropdownLink.link.toString().contains("about/connect/index"))
             <a class="icon $dropdownLink.iconClass" href="/about/connect/index" aria-label="Connect with Chapman">
-          #elseif($dropdownLink.link.toString().contains("/admission/undergraduate/how-to-apply/index"))
-            <a class="icon $dropdownLink.iconClass" href="/admission/undergraduate/how-to-apply/index">
-          #elseif($dropdownLink.link.toString().contains("discover"))
-            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="$defaultLinkName">
           #else
             <a class="icon $dropdownLink.iconClass" href="site://Chapman.edu/$dropdownLink.link">          
           #end
@@ -478,7 +474,7 @@
         <div class="utility-dropdown dropdown">
           <ul>
             <li><a href="site://Chapman.edu/future-students/index">Prospective Students</a></li>
-            <li><a href="site://Chapman.edu/students/index" >Current Students</a></li>
+            <li><a href="site://Chapman.edu/students/index">Current Students</a></li>
             <li><a href="site://Chapman.edu/alumni/index">Alumni</a></li>
             <li><a href="site://Chapman.edu/faculty-staff/index">Faculty &amp; Staff</a></li>
             <li><a href="site://Chapman.edu/families/index">Parents &amp; Families</a></li>
@@ -645,7 +641,7 @@
         <ul>
           <li><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
           <li><a href="site://Chapman.edu/about/visit/index">Visit Chapman</a></li>
-          <li><a href="site://Chapman.edu/discover/index" aria-label="Discover Chapman">Discover Chapman</a></li>
+          <li><a href="site://Chapman.edu/discover/index">Discover Chapman</a></li>
           <li><a href="site://Chapman.edu/about/facts-and-rankings/index">Facts &amp; Rankings</a></li>
           <li><a href="site://Chapman.edu/about/our-family/leadership/index">Leadership</a></li>
           <li><a href="site://Chapman.edu/campus-services/index">Campus Services</a></li>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -442,9 +442,9 @@
           #elseif($dropdownLink.link.toString().contains("support-chapman/get-involved"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman: Get Involved">
           #elseif($dropdownLink.link.toString().contains("about/connect/index"))
-            <a class="icon $dropdownLink.iconClass" href="https://www.chapman.edu/about/connect/index.aspx" aria-label="Connect with Chapman">
-          #elseif($dropdownLink.link.toString().contains("undergraduate/applynow"))
-            <a class="icon $dropdownLink.iconClass" href="https://www.chapman.edu/admission/undergraduate/applynow">
+            <a class="icon $dropdownLink.iconClass" href="/about/connect/index" aria-label="Connect with Chapman">
+          #elseif($dropdownLink.link.toString().contains("/admission/undergraduate/how-to-apply/index"))
+            <a class="icon $dropdownLink.iconClass" href="/admission/undergraduate/how-to-apply/index">
           #elseif($dropdownLink.link.toString().contains("discover"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="$defaultLinkName">
           #else
@@ -649,7 +649,7 @@
           <li><a href="site://Chapman.edu/about/facts-and-rankings/index">Facts &amp; Rankings</a></li>
           <li><a href="site://Chapman.edu/about/our-family/leadership/index">Leadership</a></li>
           <li><a href="site://Chapman.edu/campus-services/index">Campus Services</a></li>
-          <li><a href="https://dev-www.chapman.edu/about/connect/index.aspx">Connect</a></li>
+          <li><a href="site://Chapman.edu/about/connect/index">Connect</a></li>
         </ul>
       </li>
       <li>
@@ -670,7 +670,7 @@
         #buildToggleIcon("Admission")
         <ul>
           <li><a href="site://Chapman.edu/admission/undergraduate/index">Undergraduate Admission</a></li>
-          <li><a href="https://www.chapman.edu/admission/undergraduate/applynow">Undergraduate Application</a></li>
+          <li><a href="site://Chapman.edu/admission/undergraduate/how-to-apply/index">Undergraduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/index">Graduate Admission</a></li>
           <li><a href="site://Chapman.edu/admission/graduate/applynow">Graduate Application</a></li>
           <li><a href="site://Chapman.edu/admission/undergraduate/afford">Affordability</a></li>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -431,9 +431,22 @@
         <a class="icon $overviewIconClass" href="site://Chapman.edu/$overviewLink">$parentPage Overview</a>
       </li>
       #foreach( $dropdownLink in $dropdownLinks )
-        <li>
+        #set ($defaultLinkName = "${_EscapeTool.xml( $dropdownLink.text )}")
+          <li>
           #if($dropdownLink.link.toString().contains("http"))
             <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link">
+          #elseif($dropdownLink.link.toString().contains("about/connect/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect">
+          #elseif($dropdownLink.link.toString().contains("alumni/events/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni events">
+          #elseif($dropdownLink.link.toString().contains("alumni/get-involved/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Alumni - get involved">
+          #elseif($dropdownLink.link.toString().contains("support-chapman/get-involved"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Support Chapman - get involved">
+          #elseif($dropdownLink.link.toString().contains("about/connect/"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="Connect with Chapman">
+          #elseif($dropdownLink.link.toString().contains("discover"))
+            <a class="icon $dropdownLink.iconClass" href="$dropdownLink.link" aria-label="$defaultLinkName">
           #else
             <a class="icon $dropdownLink.iconClass" href="site://Chapman.edu/$dropdownLink.link">          
           #end
@@ -465,7 +478,7 @@
         <div class="utility-dropdown dropdown">
           <ul>
             <li><a href="site://Chapman.edu/future-students/index">Prospective Students</a></li>
-            <li><a href="site://Chapman.edu/students/index">Current Students</a></li>
+            <li><a href="site://Chapman.edu/students/index" >Current Students</a></li>
             <li><a href="site://Chapman.edu/alumni/index">Alumni</a></li>
             <li><a href="site://Chapman.edu/faculty-staff/index">Faculty &amp; Staff</a></li>
             <li><a href="site://Chapman.edu/families/index">Parents &amp; Families</a></li>
@@ -475,10 +488,10 @@
       <li class="utility-cell"><a href="site://Chapman.edu/academics/degrees-and-programs">Degrees &amp; Programs</a></li>
       <li class="utility-cell"><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
       <li class="utility-cell"><a href="site://Chapman.edu/directory/index">All Directories</a></li>
-      <li class="utility-cell"><a href="https://news.chapman.edu/">News</a></li>
-      <li class="utility-cell"><a href="https://events.chapman.edu/">Events</a></li>
+      <li class="utility-cell"><a href="https://news.chapman.edu/" aria-label="Chapman Newsroom">News</a></li>
+      <li class="utility-cell"><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
       <li class="utility-cell utility-has-dropdown">
-        <a href="#">Social</a>
+        <a href="#" role="listbox" aria-label="Social listbox">Social</a>
         <div class="utility-dropdown social-dropdown dropdown">
           <ul>
             <li>
@@ -632,7 +645,7 @@
         <ul>
           <li><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
           <li><a href="site://Chapman.edu/about/visit/index">Visit Chapman</a></li>
-          <li><a href="site://Chapman.edu/discover/index">Discover Chapman</a></li>
+          <li><a href="site://Chapman.edu/discover/index" aria-label="Discover Chapman">Discover Chapman</a></li>
           <li><a href="site://Chapman.edu/about/facts-and-rankings/index">Facts &amp; Rankings</a></li>
           <li><a href="site://Chapman.edu/about/our-family/leadership/index">Leadership</a></li>
           <li><a href="site://Chapman.edu/campus-services/index">Campus Services</a></li>
@@ -669,8 +682,8 @@
         <a href="site://Chapman.edu/alumni/index">Alumni</a>
         #buildToggleIcon("Alumni")
         <ul>
-          <li><a href="site://Chapman.edu/alumni/events/index">Events</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/events/index" aria-label="Alumni Events">Events</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
           <li><a href="site://Chapman.edu/campus-services/career-professional-development/index">Career Support</a></li>
         </ul>
       </li>
@@ -681,7 +694,7 @@
         <ul>
           <li><a href="http://www.chapmanathletics.com/landing/index">Athletics</a></li>
           <li><a href="site://Chapman.edu/diversity/index">Diversity &amp; Inclusion</a></li>
-          <li><a href="https://events.chapman.edu/">Events</a></li>
+          <li><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
           <li><a href="site://Chapman.edu/campus-life/fish-interfaith-center/index">Fish Interfaith Center</a></li>
           <li><a href="site://Chapman.edu/students/health-and-safety/index">Health &amp; Safety</a></li>
           <li><a href="site://Chapman.edu/students/services/housing-and-residence/index">Residence Life</a></li>
@@ -705,9 +718,9 @@
         #buildToggleIcon("Support")
         <ul>
           <li><a href="site://Chapman.edu/support-chapman/contact-us">Contact Development</a></li>
-          <li><a href="site://Chapman.edu/support-chapman/get-involved">Get Involved</a></li>
+          <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support - involvement opportunities">Get Involved</a></li>
           <li><a href="site://Chapman.edu/support-chapman/ways-to-give/areas-to-support">Areas to Support</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni Involvement</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni - get involved</a></li>
         </ul>
       </li>
     </ul>
@@ -728,9 +741,9 @@
         <li><a href="site://Chapman.edu/academics/degrees-and-programs">Degrees &amp; Programs</a></li>
         <li><a href="site://Chapman.edu/about/maps-directions/index">Maps &amp; Directions</a></li>
         <li><a href="site://Chapman.edu/directory/index">All Directories</a></li>
-        <li><a href="https://news.chapman.edu/">News</a></li>
-        <li><a href="https://events.chapman.edu/">Events</a></li>
-        <li><a href="https://social.chapman.edu/">Social</a></li>
+        <li><a href="https://news.chapman.edu/" aria-label="Chapman Newsroom">News</a></li>
+        <li><a href="https://events.chapman.edu/" aria-label="Chapman Events">Events</a></li>
+        <li><a href="https://social.chapman.edu/" aria-label="Chapman Social Hub">Social</a></li>
       </ul>
     </div>
   </div>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -720,7 +720,7 @@
           <li><a href="site://Chapman.edu/support-chapman/contact-us">Contact Development</a></li>
           <li><a href="site://Chapman.edu/support-chapman/get-involved" aria-label="Support - involvement opportunities">Get Involved</a></li>
           <li><a href="site://Chapman.edu/support-chapman/ways-to-give/areas-to-support">Areas to Support</a></li>
-          <li><a href="site://Chapman.edu/alumni/get-involved/index">Alumni - get involved</a></li>
+          <li><a href="site://Chapman.edu/alumni/get-involved/index" aria-label="Alumni - get involved">Get Involved</a></li>
         </ul>
       </li>
     </ul>

--- a/.cascade-code/Chapman.edu/_config/global_nav.vm
+++ b/.cascade-code/Chapman.edu/_config/global_nav.vm
@@ -92,7 +92,7 @@
       },
       {
         'text': 'Undergraduate Application',
-        'link':'/admission/undergraduate/applynow',
+        'link':'/admission/undergraduate/how-to-apply/index',
         'iconClass': 'icon-pencil5'
       },
       {


### PR DESCRIPTION
https://trello.com/c/bNrtZRm5

Address Siteimproves "Link text used for multiple different destinations". 

Some sections use the same text to describe different links, eg `"Alumni" > "Get Involved" (https://dev-www.chapman.edu/alumni/get-involved/index.aspx)` and `"Support" > "Get Involved" (https://dev-www.chapman.edu/support-chapman/get-involved.aspx)` .  I've applied aria-labels where appropriate.

You can demo with the Siteimprove extension at https://dev-www.chapman.edu/test-section/nick-test/index1.aspx and compare against the former issues at https://my2.siteimprove.com/Inspector/10993/Accessibility/Page?pageId=31903631364&impmd=0D6974F8A4BBF3C0E325AAA2E369A7D2#/Criterion/2.4.4/Check/39

Note that Siteimprove 2.4.4 will now always display "Does the "aria-label" accurately describe the link?" ... "This warning will appear for all of your 'aria-label' on links since a manual review is needed."
