### PR TITLE
add rake task to initiate local tunnel

### DIFF
--- a/lib/tasks/serve.rake
+++ b/lib/tasks/serve.rake
@@ -1,9 +1,19 @@
+# frozen_string_literal: true
+
 desc "Runs forman start"
 task serve: :environment do
   system('bundle exec foreman start')
 end
 
+desc "Starts serveo tunnel"
+task serveo: :environment do
+  login = Etc.getlogin
+  local_tunnel = system("ssh -R #{login}:80:localhost:5000 serveo.net")
+  puts local_tunnel
+end
+
 # Alias
 task server: :environment do
   Rake::Task["serve"].invoke
+  Rake::Task["serveo"].invoke
 end


### PR DESCRIPTION
story: https://trello.com/c/QEGyufbO

After `rake serve`, `rake serveo` in a new terminal tab/window will initiate a local tunnel prefixed with your OS username (eg `https://nnadel.serveo.net`). I experimented with ngrok and localtunnel but opted for Serveo because:
1) it's simpler 
2) no installation 
3) free subdomains. 

Sometimes the Serveo connection closes and you have to run the task again, so down the road it might make sense to switch to one of the others (pending usefulness, uptime, reliability, etc...). 

Once `rake serveo` fires, you can deduce your local asset files and replace existing (copy and paste for now) references (`<link href="https://nick.serveo.net/_assets/master.self.css" media="all" rel="stylesheet"/>`) in your personal cascade-assets block (eg `cascade-assets-nick` on Cascade CMS). 

`master.js` can require running `rake assets:precompile` (if, for instance, changes to `rotator.js` are not reflected). Alternatively, you can _disable_ compression and _enable_ debugging in `development.rb` to reference the debug asset file directly with: 

```
# Do not compress assets
config.assets.compress = false

# Expands the lines which load the assets
config.assets.debug = true
```

in which case you'll be able to reference `https://nnadel.serveo.net/_assets/cascade/rotator.self-f39b0108dec9f9e6bf026c6275d6684199041680728c6e3f2518f0eba2ac3c54.js` for instant changes without running the precompile task.


Todos include:

- [ ] automatically add tunnel URLs to **staging** `dist/staging/cascade-assets.xml` (replace existing) ... or better yet, use web services to literally write to live `cascade-assets-nick.xml`. The pipe dream involves this same method of writing velocity code in your local editor and pushing via web services to the respective velocity format (`Masthead.vtl`)
- [ ] add toggle on the Dashboard Index page to initiate the tunnel and open the url in a new tab 
- [ ] display tunnel status (URL, connected/disconnected) next to toggle

