### PR TITLE
Fix - boxes masthead 3 col new target window

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/level/Masthead.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/level/Masthead.vtl
@@ -153,7 +153,7 @@
 					## Use defaults above.
 				#end
 
-				<li tabindex="0">
+				<li>
 					<a class="item" href="${_EscapeTool.xml($slideItemHref)}">
 						<img height="220"
 							 width="266"

--- a/app/assets/javascripts/cascade/rotator.js
+++ b/app/assets/javascripts/cascade/rotator.js
@@ -176,7 +176,8 @@ $(function () {
     }, 500)
     $(".breadcrumbs a:first-child").focus()
   })
-  console.log("ready!");
+  // Scroll to skip button when focus
+  $(window).scrollTop($('.peekaboo').position().top);
   // Pause carousel via button
   $('div.pause').click(function () {
     pauseAutoScroll();
@@ -188,3 +189,4 @@ $(function () {
     }
   });
 });
+

--- a/app/assets/stylesheets/regions/mastheads/boxes-masthead.scss
+++ b/app/assets/stylesheets/regions/mastheads/boxes-masthead.scss
@@ -347,3 +347,19 @@ li.jcarousel-item:active .button {
 .miniRotatorNav.next {
   top: 0;
 }
+
+.skip {
+    width: 100%;
+    text-align: center;
+    padding-top: 10px;
+    position: absolute;
+    z-index: -1;
+}
+
+.skip:focus-within {
+    width: 100%;
+    text-align: center;
+    padding-top: 10px;
+    position: relative;
+    z-index: 10;
+}

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -46,10 +46,6 @@
           <text default="[description]" identifier="description" label="Description (25 words max)" multi-line="true" required="true"/>
           <text help-text="full url (including http) to page outside of Cascade" identifier="link" label="External Link"/>
           <asset identifier="internalLink" label="Or Internal Link" type="page"/>
-          <text default="Same Window" help-text="open link in New Tab or stay in same browser (default)" identifier="linkTarget" label="Target" type="dropdown">
-            <dropdown-item value="Same Window"/>
-            <dropdown-item value="New Window"/>
-          </text>
         </group>
       </group>
     </group>
@@ -138,7 +134,6 @@
         <dropdown-item value="(select one)"/>
         <dropdown-item show-fields="primaryContent/widget/carousel" value="Carousel"/>
         <dropdown-item show-fields="primaryContent/widget/collapsibleRegions" value="Collapsible Regions"/>
-        <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/faculty" value="Faculty Info"/>
         <dropdown-item show-fields="primaryContent/widget/FeaturedNewsEvents" value="Featured / News / Events"/>
         <dropdown-item show-fields="primaryContent/widget/form" value="Form"/>
@@ -150,8 +145,9 @@
         <dropdown-item show-fields="primaryContent/widget/threePhotoCallout" value="Three Photo Callout"/>
         <dropdown-item show-fields="primaryContent/widget/twitterTimeline" value="Twitter Feed"/>
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
-        <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>        
-        <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>        
+        <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
+        <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
+        <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
       </text>
       <group collapsed="true" identifier="carousel" label="Carousel">
         <text default="Yes" identifier="display-carousel" label="Show" required="true" type="radiobutton">


### PR DESCRIPTION
Follow-up to #475. I'd previously only removed the 'Same/New Window' section from the 2 Column Data Definition. This removes it from the 3 Column Data Definition and adds a few improvements to accessibility:
1) single tab through `<li>`s
2) scroll to 'Skip Carousel' on focus

story: https://trello.com/c/pGYmCKim
demo: https://dev-www.chapman.edu/test-section/nick-test/sprint-5-8-19/epay-123.aspx#