### PR TITLE
move leftover CSS causing global <label> conflicts

### DIFF
--- a/app/assets/stylesheets/themes/home.scss
+++ b/app/assets/stylesheets/themes/home.scss
@@ -487,32 +487,3 @@ h6,
 /* End of file */
 
 
-
-label.upgrade-notice {
-  float: right;
-}
-
-#upgrade-browser {
-  background-color: #FFFFBD;
-  font-size: 24px;
-  font-weight: bold;
-
-}
-
-#upgrade-hide {
-  display: none;
-  transition: 1s ease-in-out;
-}
-
-label {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-#upgrade-hide:checked~#upgrade-browser {
-  display: none;
-}
-
-#upgrade-browser a {
-  text-decoration: underline;
-}

--- a/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
+++ b/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
@@ -59,6 +59,29 @@ div.upgrade-browser-wrapper {
     text-decoration: underline;
     display: inline;
   }
+
+  label.upgrade-notice {
+    float: right;
+  }
+
+  #upgrade-browser {
+    background-color: #FFFFBD;
+    font-size: 24px;
+    font-weight: bold;
+  }
+
+  label {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  #upgrade-hide:checked~#upgrade-browser {
+    display: none;
+  }
+
+  #upgrade-browser a {
+    text-decoration: underline;
+  }
 }
 
 // Show alert on browsers where flex is unsupported


### PR DESCRIPTION
Resolves global styling issue with `<label>` related to the new upgrade-alert notice. 

before: https://www.chapman.edu/website-feedback-form.aspx
after: https://dev-www.chapman.edu/website-feedback-form.aspx