### PR TITLE
Hotfix - min supported browsers

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -847,17 +847,18 @@
 #setVars()
 #buildOmniNav()
 
+
 ## Browser Upgrade Alert 
 <div class="upgrade-browser-wrapper">
     <input type="checkbox" id="upgrade-hide"/>
     <label for="upgrade-hide" class="upgrade-notice dismiss">
         <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
     </label>
-    <br>
+    <br/>
     <div id="upgrade-browser">
         <p class="inner">
             Please update your browser for the best viewing experience.
-            <br>
+            <br/>
             <span class="fr dismiss">
                 <a href="https://www.chapman.edu/upgrade-browser.aspx">learn more</a>
                 or
@@ -866,7 +867,7 @@
             </span>
             <span id="persistence">
                 <label>
-                    <input aria-role="do not show message again" type="checkbox">
+                    <input aria-role="do not show message again" type="checkbox"/>
                     Do not show this message again
                 </label>
             </span>

--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -849,17 +849,27 @@
 
 ## Browser Upgrade Alert 
 <div class="upgrade-browser-wrapper">
-  <input type="checkbox" id="upgrade-hide" />
-  <div id="upgrade-browser">
-    <label for="upgrade-hide" class="upgrade-notice">
-      <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
+    <input type="checkbox" id="upgrade-hide"/>
+    <label for="upgrade-hide" class="upgrade-notice dismiss">
+        <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
     </label>
-    <p class="inner">
-      Please update your browser for the best viewing experience.
-      <span class="fr">
-        <a href="https://www.chapman.edu/upgrade-browser.aspx">learn more</a> or <span class="linklike"
-          role="dismiss upgrade alert" onclick="dismiss()">dismiss</span>
-      </span>
-    </p>
-  </div>
+    <br>
+    <div id="upgrade-browser">
+        <p class="inner">
+            Please update your browser for the best viewing experience.
+            <br>
+            <span class="fr dismiss">
+                <a href="https://www.chapman.edu/upgrade-browser.aspx">learn more</a>
+                or
+                <span class="linklike" role="dismiss upgrade alert">dismiss</span>
+                <br/>
+            </span>
+            <span id="persistence">
+                <label>
+                    <input aria-role="do not show message again" type="checkbox">
+                    Do not show this message again
+                </label>
+            </span>
+        </p>
+    </div>
 </div>

--- a/app/assets/javascripts/widgets/upgrade_alert.js
+++ b/app/assets/javascripts/widgets/upgrade_alert.js
@@ -8,7 +8,6 @@ function localStorageAvailable() {
   if (typeof (Storage) !== "undefined") {
     $('#persistence input').click(function () {
       if ($("#persistence input").is(':checked')) {
-        console.log('checked')
         if (localStorageAvailable())
           localStorage.DoNotShowMessageAgain = "true";
       }
@@ -32,7 +31,6 @@ function cacheDismissal() {
 function checkPref() {
   if (localStorageAvailable()) {
     if (localStorage.DoNotShowMessageAgain && localStorage.DoNotShowMessageAgain === "true") {
-      console.log('remembering prefs')
       $('div.upgrade-browser-wrapper, #upgrade-browser').css('display', 'none')
     }
   };

--- a/app/assets/javascripts/widgets/upgrade_alert.js
+++ b/app/assets/javascripts/widgets/upgrade_alert.js
@@ -1,10 +1,44 @@
 function dismiss() {
-  $('div.upgrade-browser-wrapper > a.dismiss, div.upgrade-browser-wrapper span.dismiss, div.upgrade-browser-wrapper label.upgrade-notice').click(function () {
+  $('div.upgrade-browser-wrapper > a.dismiss, div.upgrade-browser-wrapper span.dismiss, div.upgrade-browser-wrapper label.upgrade-notice, div.upgrade-browser-wrapper label.label-dismiss, div.upgrade-browser-wrapper div.dismiss').click(function () {
     $('div.upgrade-browser-wrapper, #upgrade-browser').css('display', 'none')
   })
 }
 
-$(function() {
-  dismiss();
-});
+function localStorageAvailable() {
+  if (typeof (Storage) !== "undefined") {
+    $('#persistence input').click(function () {
+      if ($("#persistence input").is(':checked')) {
+        console.log('checked')
+        if (localStorageAvailable())
+          localStorage.DoNotShowMessageAgain = "true";
+      }
+    })
+    return true;
 
+  } else {
+    return false;
+  }
+}
+
+function cacheDismissal() {
+  $('#persistence').click(function () {
+    if ($('#persistence').attr('checked')) {
+      if (localStorageAvailable())
+        localStorage.DoNotShowMessageAgain = "true";
+    }
+  })
+}
+
+function checkPref() {
+  if (localStorageAvailable()) {
+    if (localStorage.DoNotShowMessageAgain && localStorage.DoNotShowMessageAgain === "true") {
+      console.log('remembering prefs')
+      $('div.upgrade-browser-wrapper, #upgrade-browser').css('display', 'none')
+    }
+  };
+}
+$(function () {
+  checkPref();
+  dismiss();
+  cacheDismissal();
+});

--- a/app/assets/javascripts/widgets/upgrade_alert.js
+++ b/app/assets/javascripts/widgets/upgrade_alert.js
@@ -1,6 +1,6 @@
 function dismiss() {
-  $('a.dismiss, span.dismiss, div.dismiss, input.dismiss').click(function () {
-    $('#upgrade-browser').css('display', 'none')
+  $('div.upgrade-browser-wrapper > a.dismiss, div.upgrade-browser-wrapper span.dismiss, div.upgrade-browser-wrapper label.upgrade-notice').click(function () {
+    $('div.upgrade-browser-wrapper, #upgrade-browser').css('display', 'none')
   })
 }
 

--- a/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
+++ b/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
@@ -1,20 +1,3 @@
-div.upgrade-browser-wrapper {
-  position: absolute;
-  top: 0;
-  z-index: 1001;
-  width: 100%;
-  height: 60px;
-}
-
-#upgrade-browser {
-  background-color: #FFFFBD;
-  font-size: 24px;
-  font-weight: bold;
-  height: 100%;
-  font-family: $futura-regular;
-  z-index: 1;
-}
-
 #upgrade-browser {
   #upgrade-hide {
     display: none;
@@ -37,9 +20,6 @@ div.upgrade-browser-wrapper {
 
   p {
     position: relative;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    transform: translateY(-50%);
     text-align: center;
     font-weight: bold;
   }
@@ -63,19 +43,33 @@ div.upgrade-browser-wrapper {
 
 // Show alert on browsers where flex is unsupported
 @supports not (display: grid) {
+  div.upgrade-browser-wrapper {
+    position: relative;
+    top: 0;
+    width: 100%;
+    height: 100px;
+    background-color: #FFFFBD;
+  }
+
   #upgrade-browser {
+    font-size: 24px;
+    font-weight: bold;
+    height: 100%;
+    font-family: $futura-regular;
     display: block;
   }
 }
 
-// Hide on all browsers that support flex
+// Hide on all browsers that support grid
 @supports (display: grid) {
-  #upgrade-browser {
+
+  #upgrade-browser,
+  div.upgrade-browser-wrapper {
     display: none !important;
   }
 }
 
-// Microsoft Edge (supports flex eg covered above. leaving here in case needed later)
+// Microsoft Edge (supports grid eg covered above. leaving here in case needed later)
 @supports (-ms-ime-align: auto) {
   #upgrade-browser {
     // display: none !important;
@@ -86,11 +80,7 @@ div.upgrade-browser-wrapper {
 // https://www.chapman.edu/upgrade-browser.aspx requires supporting 11
 @media all and (-ms-high-contrast:none) {
   .hide {
-    visibility: hidden;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    display: none !important;
   }
 
   /* IE10 */

--- a/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
+++ b/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
@@ -1,3 +1,7 @@
+div.upgrade-browser-wrapper {
+  background-color: #FFFFBD;
+}
+
 #upgrade-browser {
   #upgrade-hide {
     display: none;
@@ -18,10 +22,15 @@
     text-decoration: none;
   }
 
+  input {
+    color: #2f2f2f;
+  }
   p {
     position: relative;
     text-align: center;
-    font-weight: bold;
+    color: #2f2f2f;
+    padding: 8px 12px 8px 50px;
+    line-height: 1.4em;
   }
 
   p.inner {
@@ -52,8 +61,6 @@
   }
 
   #upgrade-browser {
-    font-size: 24px;
-    font-weight: bold;
     height: 100%;
     font-family: $futura-regular;
     display: block;

--- a/app/views/layouts/home_page.html.erb
+++ b/app/views/layouts/home_page.html.erb
@@ -1,13 +1,10 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-
 <%= render 'widgets/shared/head' %>
-
 <!--[if lt IE 7]> <body class="ie6 oldie""> <![endif]-->
 <!--[if IE 7]>    <body class="ie7 oldie""> <![endif]-->
 <!--[if IE 8]>    <body class="ie8 oldie""> <![endif]-->
 <!--[if gt IE 8]><!-->
-
 <style>
   a.button.smc-cta:focus-visible {
     opacity: 1 !important;
@@ -18,7 +15,6 @@
 <body>
   <!--<![endif]-->
   <%= render '_cascade/blocks/html/jump_link' %>
-
   <div id="fb-root"></div>
   <%# <div class="emergency-alert">
     <span class="close-alert-trigger">
@@ -78,31 +74,43 @@
   </section>
   <div id="container">
     <%= render 'widgets/shared/header' %>
-
+    <style>
+      span#persistence {
+        display: block;
+        font-size: 16px;
+        text-align: center;
+      }
+    </style>
     <div class="upgrade-browser-wrapper">
       <input type="checkbox" id="upgrade-hide" />
+      <label for="upgrade-hide" class="upgrade-notice dismiss">
+        <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
+      </label>
+      <br>
       <div id="upgrade-browser">
-        <label for="upgrade-hide" class="upgrade-notice">
-          <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
-        </label>
         <p class="inner">
           Please update your browser for the best viewing experience.
-
+          <br>
           <span class="fr dismiss">
-            <a href="https://www.chapman.edu/upgrade-browser.aspx">learn more</a> or <span class="linklike"
-              role="dismiss upgrade alert">dismiss</span>
+            <a href="https://www.chapman.edu/upgrade-browser.aspx">learn more</a> or
+            <span class="linklike" role="dismiss upgrade alert">dismiss</span>
+            <br />
+          </span>
+          <span id="persistence">
+            <label>
+              <input aria-role="do not show message again" type="checkbox">
+              Do not show this message again
+            </label>
           </span>
         </p>
       </div>
     </div>
-
-
     <div class="homepage" id="main" role="main">
       <h1 style="display: none;">Chapman University</h1>
       <%= yield(:primary_content) %>
     </div>
     <%= yield(:footer) %>
-
   </div>
 </body>
+
 </html>


### PR DESCRIPTION
This is a follow-up to https://trello.com/c/5Iw1jIh7 

Essentially, the alert was hidden, but blocking Omninav links (`position: absolute` + `z-index`). That code was removed, so it's not currently an issue. This resolves that problem and maintains functionality. 

I've also added the option to 'Do not display this message again' via local storage, which will save the pref until cookies/cache are cleared. 

I've tested, but if anyone has time I'd really appreciate additional eyes/ stringent testing before pushing to WWW. 

example: https://live.browserstack.com/dashboard#os=Windows&os_version=XP&browser=IE&browser_version=8.0&zoom_to_fit=true&full_screen=true&resolution=responsive-mode&url=http%3A%2F%2Flocalhost%3A5000%2Fhome_page%2Fsample&speed=1&host_ports=google.com%2C80%2C0