### PR TITLE
resolves Wave's "X Empty form label"

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -852,7 +852,9 @@
 <div class="upgrade-browser-wrapper">
     <input type="checkbox" id="upgrade-hide"/>
     <label for="upgrade-hide" class="upgrade-notice dismiss">
-        <a class="fa fa-window-close no-underline" aria-hidden="true"></a>
+        <a class="fa fa-window-close no-underline" aria-hidden="true">
+        <span class="sr-only">dismiss alert</span>
+        </a>
     </label>
     <br/>
     <div id="upgrade-browser">


### PR DESCRIPTION
story: https://trello.com/c/wwpYthB8
before: https://www.chapman.edu/
after: https://dev-www.chapman.edu/test-section/nick-test/sprint-6-6-2019/wave-upgrade-alert-empty-form.aspx 