### PR TITLE
changes social icons to default on communication/about

### DIFF
--- a/app/assets/stylesheets/themes/communication.scss
+++ b/app/assets/stylesheets/themes/communication.scss
@@ -24,14 +24,14 @@
   #social_follow_us {
 
     .banner {
-      background-image: image-url('communication_follow_us.png');
+      background-image: image-url('default_follow_us.png');
     }
 
     li span {
 
       &.hover_state,
       &.inactive_state {
-        background-image: image-url('communication_icons.png');
+        background-image: image-url('default_icons.png');
       }
     }
   }


### PR DESCRIPTION
Follow-up to https://github.com/chapmanu/cascade-assets/pull/487

(I'd missed the custom social PNGs on Comm's two column pages)

before: https://www.chapman.edu/communication/about.aspx
after: https://dev-www.chapman.edu/test-section/nick-test/sprint-6-6-2019/communication/about.aspx