### PR TITLE
Defect - one col widgets

### DIFF
--- a/app/assets/javascripts/widgets/image_slider.js
+++ b/app/assets/javascripts/widgets/image_slider.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
     thumbItem: 9,
     slideMargin: 0,
     speed: 500,
-    pause: 4000,
+    pause: 10000,
     auto: true,
     loop: true,
     keyPress: true,

--- a/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
+++ b/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
@@ -1,80 +1,86 @@
 .call-to-action-3-up-widget {
-	padding: $one-column-widget-spacing 0;
-	background-color: #eaeaea;
-	
-	.outer-container {
-		@include outer-container();
-	}
+  padding: $one-column-widget-spacing 0;
+  background-color: #eaeaea;
 
-	.column {
-		margin-bottom: $base-spacing*3;
-		&:last-child { margin-bottom: 0; }
-		@include media($medium-screen) {
-			margin-bottom: 0;
-			@include span-columns(6);
-			@include pad(0 default);
-		}
-	}
+  .outer-container {
+    @include outer-container();
+  }
 
-	h2.headline {
-		@include section_heading();
-		margin: 24px 0 0;
+  .column {
+    margin-bottom: $base-spacing*3;
 
-		@include media($medium-screen) {
-			@include sub_section_heading();
-		}
+    &:last-child {
+      margin-bottom: 0;
+    }
 
-		@include media(min-width 800px) {
-			@include section_heading();
-		}
-	}
+    @include media($medium-screen) {
+      margin-bottom: 0;
+      @include span-columns(6);
+      @include pad(0 default);
+    }
+  }
 
-	.image-wrap {
-		@include aspect_ratio(3, 2);
-		position: relative;
-		overflow: hidden;
-		max-width: 900px;
-		max-height: 400px;
-		width: auto;
-		height: auto;
+  h2.headline {
+    @include section_heading();
+    margin: 24px 0 0;
 
-		img {
-			height: 100%;
-			width: 100%;
-		}
-	}
+    @include media($medium-screen) {
+      @include sub_section_heading();
+    }
 
-	.text-wrap {
-		display: inline-block;
-		@include pad($base-spacing*2 $base-spacing*2 0);
+    @include media(min-width 800px) {
+      @include section_heading();
+    }
+  }
 
-		@include media($medium-screen) {
-			@include pad(0 default);
-		}
+  .image-wrap {
+    @include aspect_ratio(3, 2);
+    position: relative;
+    overflow: hidden;
+    max-width: 900px;
+    max-height: 400px;
+    width: auto;
+    height: auto;
 
-		@include media($large-screen) {
-			padding: 0;
-		}
+    img {
+      height: 100%;
+      width: 100%;
+    }
+  }
 
-		@include media(min-width 800px) {
-			@include pad(0 default);
-		}
-	}
+  .text-content {
+    padding-bottom: 44px;
+  }
 
-	p {
-		@include paragraph();
-		margin: 0;
-	}
+  .text-wrap {
+    display: inline-block;
+    @include pad($base-spacing*2 $base-spacing*2 0);
 
-	a.more-link {
-		@include hyperlinks();
-		display: inline-block;
-		margin-top: 44px;
+    @include media($medium-screen) {
+      @include pad(0 default);
+    }
 
-		&:after {
-			content: " »"
-		}
-	}
+    @include media($large-screen) {
+      padding: 0;
+    }
+
+    @include media(min-width 800px) {
+      @include pad(0 default);
+    }
+  }
+
+  p {
+    @include paragraph();
+    margin: 0;
+  }
+
+  a.more-link {
+    @include hyperlinks();
+
+    &:after {
+      content: " »"
+    }
+  }
 }
 
 .call-to-action-3-up-widget__medium-bg {

--- a/app/assets/stylesheets/widgets/single_column/image_slider.scss
+++ b/app/assets/stylesheets/widgets/single_column/image_slider.scss
@@ -1,11 +1,10 @@
 .image-slider-wrapper {
-
-  .image-slider {
-    margin-top: 64px;
-    margin-bottom: 64px;
+  .container {
+    margin-top: 0;
   }
 
-  h1, .faux-h1 {
+  h1,
+  .faux-h1 {
     font-family: $futura-regular;
     font-weight: 700;
     font-size: 24px;
@@ -16,9 +15,12 @@
     margin-bottom: 2%;
   }
 
-  h1.title, .faux-h1.title,
-  h2.title, .faux-h2.title,
-  h3.title, .faux-h3.title {
+  h1.title,
+  .faux-h1.title,
+  h2.title,
+  .faux-h2.title,
+  h3.title,
+  .faux-h3.title {
     margin-top: -30px;
     padding-top: 0;
   }
@@ -82,6 +84,11 @@
     width: auto;
   }
 
+  .lSSlideOuter {
+    margin-bottom: -5px;
+    overflow: unset;
+  }
+
   .lSSlideOuter .lSPager.lSpg {
     margin: 10px 0 0;
     padding: 0;
@@ -134,6 +141,27 @@
       -webkit-line-clamp: 5;
       -webkit-box-orient: vertical;
     }
+
+    .line-clamp:after {
+      content: "";
+    }
+  }
+
+  @supports not (-webkit-line-clamp: 2) {
+    .line-clamp {
+      position: relative;
+      height: 6em;
+    }
+
+    .line-clamp:after {
+      content: "";
+      text-align: right;
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 70%;
+      height: 1.2em;
+    }
   }
 
   // Media Queries
@@ -184,6 +212,12 @@
       right: 0;
       right: 4%;
       float: right;
+    }
+
+    .line-clamp {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
     }
   }
 


### PR DESCRIPTION
Followup to #496 where I'd committed unintentional files. 

story: https://trello.com/c/tSTrMk5B

- [ ] Image slider Widget: There is weird padding top and bottom. Can we remove?
- [ ] On the 3-box callout, the underline for the links looks funky. Goes all the way across even if know words are present.
- [ ] On the text with image widget, at the bottom transition to the next widget, I get this happening often with the overlap.

Note: I was unable to replicate `On the text with image widget, at the bottom transition to the next widget, I get this happening often with the overlap` on existing `before` page or dev `after` page

 
before: https://www.chapman.edu/industry-partners/index.aspx
after: https://dev-www.chapman.edu/test-section/nick-test/sprint-6-19-2019/image-slider-no-padding.aspx