### PR TITLE
Defect - 1col widgets

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/call_to_action_3_up.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/call_to_action_3_up.vtl
@@ -35,7 +35,7 @@
         <div class="text-wrap">
             <h2 class="headline">$title</h2>
             <p class="text-content">$body</p>
-            <a #outputHref($link) class="more-link">$label</a>
+            <a #outputHref($link) class="more-link"><span class="underline">$label</span></a>
         </div>
     </div>
 #end

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/image_slider_widget.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/image_slider_widget.vtl
@@ -53,7 +53,8 @@
                 <h1 class="headline">$_EscapeTool.xml($featuredTitle)</h1>
              
             ##  USEFUL TEXT-CLIPPING FUNCTION, PRE-WYSIWYG. NEED TO REFACTOR FOR WYSIWYG. 
-                <p class="description line-clamp">${_DisplayTool.truncate($featuredBody,500,"...")}</p>
+                ## <p class="description line-clamp">${_DisplayTool.truncate($featuredBody,500,"...")}</p>
+                <p class="description line-clamp">$_EscapeTool.xml($featuredBody)</p>
                  #if ( $featuredLinkExists )
                       <a #outputHref($featuredLink) class="theme-bg-color theme-button">$_EscapeTool.xml($featuredLink.getChild('label').value)</a>
                 #end

--- a/app/assets/javascripts/widgets/image_slider.js
+++ b/app/assets/javascripts/widgets/image_slider.js
@@ -10,6 +10,7 @@ $(document).ready(function () {
     loop: true,
     keyPress: true,
     pauseOnHover: false,
+    adaptiveHeight: true,
     // useCSS: true,
     onSliderLoad: function () {
       $(".widget-slides").removeClass("cS-hidden");

--- a/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
+++ b/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
@@ -48,10 +48,6 @@
     }
   }
 
-  .text-content {
-    padding-bottom: 44px;
-  }
-
   .text-wrap {
     display: inline-block;
     @include pad($base-spacing*2 $base-spacing*2 0);
@@ -76,10 +72,17 @@
 
   a.more-link {
     @include hyperlinks();
+    display: inline-block;
+    margin-top: 44px;
+    border-bottom: unset;
 
     &:after {
       content: " »"
     }
+  }
+  span.underline {
+      border-bottom: 1px dotted #a50034;
+      line-height: 1.2em;
   }
 }
 

--- a/app/assets/stylesheets/widgets/single_column/image_slider.scss
+++ b/app/assets/stylesheets/widgets/single_column/image_slider.scss
@@ -85,8 +85,8 @@
   }
 
   .lSSlideOuter {
-    margin-bottom: -5px;
     overflow: unset;
+    margin-bottom: -20px;
   }
 
   .lSSlideOuter .lSPager.lSpg {
@@ -135,34 +135,15 @@
     line-height: 22px;
   }
 
-  @supports (-webkit-line-clamp: 2) {
-    .line-clamp {
-      display: -webkit-box;
-      -webkit-line-clamp: 5;
-      -webkit-box-orient: vertical;
-    }
-
-    .line-clamp:after {
-      content: "";
+  @media screen and (min-width: 1024px) {
+    .content-text .description {
+      overflow-y: auto;
+      height: auto;
+      max-height: 17rem;
+      overflow-y: scroll;
     }
   }
 
-  @supports not (-webkit-line-clamp: 2) {
-    .line-clamp {
-      position: relative;
-      height: 6em;
-    }
-
-    .line-clamp:after {
-      content: "";
-      text-align: right;
-      position: absolute;
-      bottom: 0;
-      right: 0;
-      width: 70%;
-      height: 1.2em;
-    }
-  }
 
   // Media Queries
   @media screen and (max-width: 1480px) {
@@ -197,6 +178,13 @@
       left: 0;
       margin-left: 0;
     }
+
+    .content-container-slider {
+      min-height: 100%;
+      display: grid;
+      grid-auto-columns: 1fr;
+      align-items: center;
+    }
   }
 
   @media screen and (max-width: 535px) {
@@ -213,12 +201,6 @@
       right: 4%;
       float: right;
     }
-
-    .line-clamp {
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-    }
   }
 
   @media screen and (max-width: 435px) {
@@ -228,7 +210,6 @@
       align-items: space-around;
       text-align: left;
       margin-top: -10px;
-      min-height: 220px;
     }
 
     .content-box a.button.red.smc-cta {
@@ -293,7 +274,7 @@
     }
   }
 
-  @media screen and (max-width: 780px) {
+  @media screen and (max-width: 1024px) {
     img {
       height: 400px;
     }
@@ -312,7 +293,6 @@
       display: block;
       position: relative;
       margin-top: -5px;
-      min-height: 200px;
       padding-bottom: 2em;
       background-color: $panther-black;
     }

--- a/app/views/widgets/single_column/_call_to_action_3_up.html
+++ b/app/views/widgets/single_column/_call_to_action_3_up.html
@@ -9,7 +9,7 @@
 				<p class="text-content">
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet libero ultrices, aliquam ligula eu, sodales ligula. Ut maximus mauris tincidunt maximus hendrerit. Nullam velit felis, ultricies sit amet efficitur at, aliquet vitae velit.
 				</p>
-				<a class="more-link theme-button">See More Information</a>
+				<a class="more-link"><span class="underline">This link text is a little longer than expected. Underline should wrap...</span></a>
 			</div>
 		</div>
 		<div class="column">
@@ -17,7 +17,7 @@
 				<a href= ""><img class= "image" src="http://www.critterbabies.com/wp-content/gallery/kittens/Cute-Kitten-kittens-16122946-1280-800.jpg"/></a>
 			</div>
 			<div class= "text-wrap">
-				<h2 class="headline">Sample CTA Column</h2>
+				<h2 class="headline">Sample CTA Column but it's longer than expected</h2>
 				<p class="text-content">
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet libero ultrices, aliquam ligula eu, sodales ligula. Ut maximus mauris tincidunt maximus hendrerit. Nullam velit felis, ultricies sit amet efficitur at, aliquet vitae velit.
 				</p>


### PR DESCRIPTION
Ross noticed a few lingering issues on https://www.chapman.edu/industry-partners/index.aspx, namely:
- spacing below the CTA 3-up headings
- some height issues on the image slider which I discovered were related to the WYSWIYG adding empty `<p>` tags / additional rich text formatting depending on how content was pasted. 
- removed text-truncating on the Image Slider velocity format
- Image Slider content area attempts to accommodate a large amount of text (instead of line-clamp)... even though web coordinators would likely prevent this scenario from occurring 

before: https://www.chapman.edu/industry-partners/index.aspx
after: https://dev-www.chapman.edu/test-section/nick-test/sprint-6-19-2019/industry-partners.aspx
