### PR TITLE
Remove unused linkTarget reference

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/level/Masthead.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/level/Masthead.vtl
@@ -133,7 +133,6 @@
 			#foreach($slide in $slides)
 				#set ( $slideInternalLinkPath = $_XPathTool.selectSingleNode($slide, 'internalLink/path').value )
 				#set ( $slideLinkText = $_XPathTool.selectSingleNode($slide, 'link').value )
-				#set ( $slideLinkTarget = $_XPathTool.selectSingleNode($slide, 'linkTarget').value )
 				#set ( $slideImagePath = $_XPathTool.selectSingleNode($slide, 'image/path').value )
 				#set ( $slideImageAltText = $_XPathTool.selectSingleNode($slide, 'altText').value )
 				#set ( $slideHeader = $_XPathTool.selectSingleNode($slide, 'header').value )


### PR DESCRIPTION
Mandy noticed I'd left an unused link target reference in Masthead.vtl, related to https://github.com/chapmanu/cascade-assets/pull/475/files#diff-20fd19a42072422f401b0ad55e64ea2f

demo: https://dev-cascade.chapman.edu/entity/open.act?id=8f89d8cfc0a81e4b2afe10e73a0e6b94&type=page