### PR TITLE
Defect - ie11/upgrade alert partially showing

### DIFF
--- a/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
+++ b/app/assets/stylesheets/widgets/home_page/upgrade_alert.scss
@@ -25,6 +25,7 @@ div.upgrade-browser-wrapper {
   input {
     color: #2f2f2f;
   }
+
   p {
     position: relative;
     text-align: center;
@@ -120,7 +121,7 @@ div.upgrade-browser-wrapper {
 
   /* IE11 */
   *::-ms-backdrop,
-  #upgrade-browser {
+  div.upgrade-browser-wrapper {
     display: none !important;
   }
 }


### PR DESCRIPTION
Spike/story https://trello.com/c/YKuuU27o (comments and 'IE11 screenshot.jpg')

( Expected behavior is that the upgrade alert should not show at all on ie11 )

Demo: 
Browserstack: https://live.browserstack.com/dashboard#os=Windows&os_version=8.1&browser=IE&browser_version=11.0&zoom_to_fit=true&full_screen=true&resolution=responsive-mode&url=https%3A%2F%2Fwww.chapman.edu%2F&speed=1&host_ports=google.com%2C80%2C0

Page: https://dev-www.chapman.edu/test-section/nick-test/sprint-5-8-19/upgrade-browser.aspx