### PR TITLE
remove unnecessary  margin-top that was causing issues when multiple …

### DIFF
--- a/app/assets/stylesheets/widgets/primary_column/collapsibles.scss
+++ b/app/assets/stylesheets/widgets/primary_column/collapsibles.scss
@@ -137,7 +137,6 @@
   cursor: pointer;
   border-bottom: 2px dotted ;
   color: $cu-red;
-  margin-top: 1.5rem;
 
   &:focus {
     outline: unset;


### PR DESCRIPTION
This is a follow-up to an approved https://github.com/chapmanu/cascade-assets/pull/522. Mandy noticed that the 'expand all' toggle was being pushed below the accordion content. 

demo: https://dev-www.chapman.edu/test-section/nick-test/sprint-8-13-2019/collapsible-widget-expand-all-fix.aspx