### PR TITLE
New Html Block widget

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
@@ -18,6 +18,8 @@
 #import( "/_cascade/formats/modular/widgets/Shared Content - Contacts Primary Content" )
 #import( "/_cascade/formats/modular/widgets/Shared Content - Degrees Primary Content" )
 #import( "/_cascade/formats/modular/widgets/Faculty Info Primary" )
+#import( "/_cascade/formats/modular/widgets/Html Block" )
+## Reserved Block Format not finished/working:
 #import( "/_cascade/formats/modular/widgets/Reserved Block Format" )
 ##
 #set ($currentPage = $_XPathTool.selectSingleNode($contentRoot, "//system-page[@current]") )
@@ -48,14 +50,14 @@
         #outputCollapsibles($widget)
         #end
     #end
-##    
+##
     #if ($widgetType == 'Form Embed') 
         #set ($displayFormEmbed = $widget.getChild('form-embed').getChild('display-form-embed').value)
         #if ($displayFormEmbed == 'Yes')
         #outputFormEmbed($widget)
         #end
     #end
-##    
+##
     #if ($widgetType == 'Form') 
         #set ($displayForm = $widget.getChild('form').getChild('display-form').value)
         #if ($displayForm == 'Yes')
@@ -63,8 +65,6 @@
         #end
     #end
 ##     
-    ## 1/15/2019 M Thomas temporarily removed on production because Yahoo YQL api to convert xml to json is unavailable,
-    ## but 1/29/2019 putting this back in on DEV only so can troubleshoot:
     #if ($widgetType == 'Featured / News / Events') 
         #outputFeaturedNewsEvents($widget)
     #end
@@ -139,6 +139,13 @@
         #end
     #end
 ##    
+    #if ($widgetType == 'Html Block')
+        #set ($displayHtmlBlock = $widget.getChild('html-block').getChild('display-html-block').value)
+        #if ($displayHtmlBlock == 'Yes')
+        #outputHtmlBlock($widget)
+        #end
+    #end
+## not finished/working yet:  
     #if ($widgetType == 'Reserved Block-Formats')
         #set ($displayReservedBlockFormat = $widget.getChild('reserved-block-formats').getChild('display-reserved-block-formats').value)
         #if ($displayReservedBlockFormat == 'Yes')

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Html Block.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Html Block.vtl
@@ -1,0 +1,17 @@
+## Used to inject block of raw html into a page. Be careful how it's used.
+#macro(outputHtmlBlock $element)  
+##
+	#set ( $blockType = $element.getChild('html-block').getChild('block-type').value )
+##
+	#if ($blockType == "Cascade Block")
+		#set ( $codeBlock = $element.getChild('html-block').getChild('cascade-block').getChild('code-block').getChild('content').getChild('system-data-structure').value )
+		<div class="html-block-widget">
+			$codeBlock
+		</div>
+	#elseif ($blockType == "External Block") 
+		#set ( $codeBlock = $element.getChild('html-block').getChild('external-block').getChild('code-block').value )
+		<div class="html-block-widget">
+			<!--#protect$codeBlock#protect-->
+		</div>
+	#end
+#end

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -147,6 +147,8 @@
         <dropdown-item show-fields="primaryContent/widget/twitterTimeline" value="Twitter Feed"/>
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
         <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
+				<dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
+				<!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
         <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
       </text>
@@ -340,6 +342,34 @@
         </text>
         <asset help-text="choose an index block from _cascade/blocks/ folder" identifier="blockName" label="Block" type="block"/>
       </group>
+			<group collapsed="true" identifier="html-block" label="Html block">
+				<text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
+					<radio-item value="Yes"/>
+					<radio-item value="No"/>
+				</text>
+				<text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+					<radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
+					<radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
+				</text>
+				<group identifier="cascade-block" label="Cascade Block">
+					<asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
+				</group>
+				<group identifier="external-block" label="External Block">
+					<text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
+				</group>
+			</group>
+			<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+				<text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
+					<radio-item value="Yes"/>
+					<radio-item value="No"/>
+				</text>
+				<text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
+					<dropdown-item value="University-wide Faculty By Rank Listing"/>
+					<dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
+					<dropdown-item value="University-wide Presidential Fellows Listing"/>
+					<dropdown-item value="A to Z Listing"/>
+				</text>
+			</group>
       <group collapsed="true" identifier="wysiwyg-editor" label="Text Editor">
         <text default="Yes" identifier="display-wysiwyg-editor" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -148,7 +148,7 @@
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
         <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
 				<dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
-				<!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
+        <!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
         <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
       </text>
@@ -342,34 +342,35 @@
         </text>
         <asset help-text="choose an index block from _cascade/blocks/ folder" identifier="blockName" label="Block" type="block"/>
       </group>
-			<group collapsed="true" identifier="html-block" label="Html block">
-				<text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
-					<radio-item value="Yes"/>
-					<radio-item value="No"/>
-				</text>
-				<text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
-					<radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
-					<radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
-				</text>
-				<group identifier="cascade-block" label="Cascade Block">
-					<asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
-				</group>
-				<group identifier="external-block" label="External Block">
-					<text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
-				</group>
-			</group>
-			<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
-				<text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
-					<radio-item value="Yes"/>
-					<radio-item value="No"/>
-				</text>
-				<text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
-					<dropdown-item value="University-wide Faculty By Rank Listing"/>
-					<dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
-					<dropdown-item value="University-wide Presidential Fellows Listing"/>
-					<dropdown-item value="A to Z Listing"/>
-				</text>
-			</group>
+      <group collapsed="true" identifier="html-block" label="Html block">
+        <text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+          <radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
+          <radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
+        </text>
+        <group identifier="cascade-block" label="Cascade Block">
+          <asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
+        </group>
+        <group identifier="external-block" label="External Block">
+          <text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
+        </group>
+      </group>
+      <!--<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+        <text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
+          <dropdown-item value="University-wide Faculty By Rank Listing"/>
+          <dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
+          <dropdown-item value="University-wide Presidential Fellows Listing"/>
+          <dropdown-item value="A to Z Listing"/>
+        </text>
+      </group>
+      -->
       <group collapsed="true" identifier="wysiwyg-editor" label="Text Editor">
         <text default="Yes" identifier="display-wysiwyg-editor" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>

--- a/app/data_definitions/from_cascade/two_column.xml
+++ b/app/data_definitions/from_cascade/two_column.xml
@@ -149,7 +149,7 @@
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
         <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
         <dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
-				<!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
+        <!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
         <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
       </text>
@@ -377,33 +377,34 @@
         <asset help-text="choose an index block from _cascade/blocks/ folder" identifier="blockName" label="Block" type="block"/>
       </group>
       <group collapsed="true" identifier="html-block" label="Html block">
-				<text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
-					<radio-item value="Yes"/>
-					<radio-item value="No"/>
-				</text>
-				<text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
-					<radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
-					<radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
-				</text>
-				<group identifier="cascade-block" label="Cascade Block">
-					<asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
-				</group>
-				<group identifier="external-block" label="External Block">
-					<text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
-				</group>
-			</group>
-			<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
-				<text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
-					<radio-item value="Yes"/>
-					<radio-item value="No"/>
-				</text>
-				<text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
-					<dropdown-item value="University-wide Faculty By Rank Listing"/>
-					<dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
-					<dropdown-item value="University-wide Presidential Fellows Listing"/>
-					<dropdown-item value="A to Z Listing"/>
-				</text>
-			</group>
+        <text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+          <radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
+          <radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
+        </text>
+        <group identifier="cascade-block" label="Cascade Block">
+          <asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
+        </group>
+        <group identifier="external-block" label="External Block">
+          <text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
+        </group>
+      </group>
+      <!--<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+        <text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
+          <dropdown-item value="University-wide Faculty By Rank Listing"/>
+          <dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
+          <dropdown-item value="University-wide Presidential Fellows Listing"/>
+          <dropdown-item value="A to Z Listing"/>
+        </text>
+      </group>
+      -->
       <group collapsed="true" identifier="wysiwyg-editor" label="Text Editor">
         <text default="Yes" identifier="display-wysiwyg-editor" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>

--- a/app/data_definitions/from_cascade/two_column.xml
+++ b/app/data_definitions/from_cascade/two_column.xml
@@ -148,7 +148,8 @@
         <dropdown-item show-fields="primaryContent/widget/twitterTimeline" value="Twitter Feed"/>
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
         <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
-        <dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>
+        <dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
+				<!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
         <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
       </text>
@@ -375,18 +376,34 @@
         </text>
         <asset help-text="choose an index block from _cascade/blocks/ folder" identifier="blockName" label="Block" type="block"/>
       </group>
-      <group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
-        <text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
-          <radio-item value="Yes"/>
-          <radio-item value="No"/>
-        </text>
-        <text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
-          <dropdown-item value="University-wide Faculty By Rank Listing"/>
-          <dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
-          <dropdown-item value="University-wide Presidential Fellows Listing"/>
-          <dropdown-item value="A to Z Listing"/>
-        </text>
-      </group>
+      <group collapsed="true" identifier="html-block" label="Html block">
+				<text default="Yes" identifier="display-html-block" label="Show" required="true" type="radiobutton">
+					<radio-item value="Yes"/>
+					<radio-item value="No"/>
+				</text>
+				<text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+					<radio-item label="Cascade Block" show-fields="primaryContent/widget/html-block/cascade-block" value="Cascade Block"/>
+					<radio-item label="Paste In External Code" show-fields="primaryContent/widget/html-block/external-block" value="External Block"/>
+				</text>
+				<group identifier="cascade-block" label="Cascade Block">
+					<asset help-text="link to _cascade/blocks/html" identifier="code-block" label="Block" render-content-depth="unlimited" type="block"/>
+				</group>
+				<group identifier="external-block" label="External Block">
+					<text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
+				</group>
+			</group>
+			<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+				<text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
+					<radio-item value="Yes"/>
+					<radio-item value="No"/>
+				</text>
+				<text default="A to Z Listing" help-text="identifies pre-paired block and formats of data" identifier="BlockFormatType" label="Block/Format Type" type="dropdown">
+					<dropdown-item value="University-wide Faculty By Rank Listing"/>
+					<dropdown-item value="University-wide Tenure/Tenure-Track Faculty Listing"/>
+					<dropdown-item value="University-wide Presidential Fellows Listing"/>
+					<dropdown-item value="A to Z Listing"/>
+				</text>
+			</group>
       <group collapsed="true" identifier="wysiwyg-editor" label="Text Editor">
         <text default="Yes" identifier="display-wysiwyg-editor" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>


### PR DESCRIPTION
new widget to allow embedding a block of html, iframe or javascript into a page in Cascade. Just a text box, not wysiwyg editor. Specifically created for Chris Bryant to put the emergency/rave feed into a page but can be used for other things too. Is for the 2 and 3 Column Modular templates. Allows the code to be entered manually, or to pull in a block stored in /blocks folder in Cascade. either way.