### PR TITLE
restructure expand/collapse toggle 

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Collapsibles.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Collapsibles.vtl
@@ -10,12 +10,14 @@ $element.getChild('collapsibleRegions').getChild('copy'), true ) )
         <h2 class="sectionHeader">${_EscapeTool.xml($mainheader)}</h2>
     #end 
     #if ($element.getChild('collapsibleRegions').getChild('copy').value != "" or
-    $element.getChild('collapsibleRegions').getChild('copy').getChildren().size() > 0)
+        $element.getChild('collapsibleRegions').getChild('copy').getChildren().size() > 0)
         <div class="editableContent summaryText">$sectionCopy
-            <div class="toggle-expand-collapse expand" onclick="expandAll()" tabindex="0">Expand All</div>
-            <div class="toggle-expand-collapse collapse" onclick="collapseAll()" tabindex="0">Collapse All</div>
         </div>
     #end
+    <div class="row">
+        <div class="toggle-expand-collapse expand" onclick="expandAll()" tabindex="0">Expand All</div>
+        <div class="toggle-expand-collapse collapse" onclick="collapseAll()" tabindex="0">Collapse All</div>
+    </div>
     #foreach ($collapsible in $collapsibles)
         #if ($collapsible.getChild('collapsed').value == 'Yes')
             <div class="accordion collapsed">

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Collapsibles.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Collapsibles.vtl
@@ -14,6 +14,7 @@ $element.getChild('collapsibleRegions').getChild('copy'), true ) )
         <div class="editableContent summaryText">$sectionCopy
         </div>
     #end
+    <br/>
     <div class="row">
         <div class="toggle-expand-collapse expand" onclick="expandAll()" tabindex="0">Expand All</div>
         <div class="toggle-expand-collapse collapse" onclick="collapseAll()" tabindex="0">Collapse All</div>

--- a/app/assets/stylesheets/widgets/primary_column/collapsibles.scss
+++ b/app/assets/stylesheets/widgets/primary_column/collapsibles.scss
@@ -1,5 +1,4 @@
 .collapsibles-widget {
-  //padding: $primary-column-widget-spacing 0;
   margin: 0 0 20px 0;
 }
 
@@ -132,10 +131,11 @@
 }
 
 .toggle-expand-collapse {
+  margin-top: -25px;
   display: block;
   float: right;
   cursor: pointer;
-  border-bottom: 2px dotted ;
+  border-bottom: 2px dotted;
   color: $cu-red;
 
   &:focus {


### PR DESCRIPTION
The expand/collapse toggle will now display even if there is no 'intro copy' text

demo: https://dev-www.chapman.edu/test-section/nick-test/sprint-early-september-2019/collapsible-widget-expand-all-fix.aspx

<img width="763" alt="Screen Shot 2019-09-09 at 10 52 37 AM" src="https://user-images.githubusercontent.com/8109093/64554301-00dd5500-d2f0-11e9-82dd-e529f47551b3.png">
