### PR TITLE
Fixes to news events widget (fall 2019)

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/LeftColumnContent.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/LeftColumnContent.vtl
@@ -30,10 +30,11 @@
         #end
     #end
 ##
-    ## 1/15/2019 M Thomas temporarily removed on production because Yahoo YQL api to convert xml to json is unavailable,
-    ## but 1/29/2019 putting this back in on DEV only so can troubleshoot:
-    #if ($widgetType == 'Featured / News / Events') 
-        #outputFeaturedNewsEvents($widget)
+    #if ($widgetType == 'Featured / News / Events')
+        #set ($displayNewsEvents = $widget.getChild('FeaturedNewsEvents').getChild('options').value)
+        #if ($displayNewsEvents != "Do Not Show")
+            #outputFeaturedNewsEvents($widget)
+        #end
     #end
 ##
     #if ($widgetType == 'Department Contact Info')

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
@@ -50,14 +50,14 @@
         #outputCollapsibles($widget)
         #end
     #end
-##    
+##
     #if ($widgetType == 'Form Embed') 
         #set ($displayFormEmbed = $widget.getChild('form-embed').getChild('display-form-embed').value)
         #if ($displayFormEmbed == 'Yes')
         #outputFormEmbed($widget)
         #end
     #end
-##    
+##
     #if ($widgetType == 'Form') 
         #set ($displayForm = $widget.getChild('form').getChild('display-form').value)
         #if ($displayForm == 'Yes')

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
@@ -148,7 +148,7 @@
         #outputHtmlBlock($widget)
         #end
     #end
-## not finished/working yet:   
+## not finished/working yet:
     #if ($widgetType == 'Reserved Block-Formats')
         #set ($displayReservedBlockFormat = $widget.getChild('reserved-block-formats').getChild('display-reserved-block-formats').value)
         #if ($displayReservedBlockFormat == 'Yes')

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/PrimaryContent.vtl
@@ -50,23 +50,26 @@
         #outputCollapsibles($widget)
         #end
     #end
-##
+##    
     #if ($widgetType == 'Form Embed') 
         #set ($displayFormEmbed = $widget.getChild('form-embed').getChild('display-form-embed').value)
         #if ($displayFormEmbed == 'Yes')
         #outputFormEmbed($widget)
         #end
     #end
-##
+##    
     #if ($widgetType == 'Form') 
         #set ($displayForm = $widget.getChild('form').getChild('display-form').value)
         #if ($displayForm == 'Yes')
         #outputForm($widget)
         #end
     #end
-##     
-    #if ($widgetType == 'Featured / News / Events') 
-        #outputFeaturedNewsEvents($widget)
+##
+    #if ($widgetType == 'Featured / News / Events')
+        #set ($displayNewsEvents = $widget.getChild('FeaturedNewsEvents').getChild('options').value)
+        #if ($displayNewsEvents != "Do Not Show")
+            #outputFeaturedNewsEvents($widget)
+        #end
     #end
 ##    
     #if ($widgetType == 'Funnels 2up')
@@ -145,14 +148,14 @@
         #outputHtmlBlock($widget)
         #end
     #end
-## not finished/working yet:  
+## not finished/working yet:   
     #if ($widgetType == 'Reserved Block-Formats')
         #set ($displayReservedBlockFormat = $widget.getChild('reserved-block-formats').getChild('display-reserved-block-formats').value)
         #if ($displayReservedBlockFormat == 'Yes')
         #outputReservedBlockFormat($widget)
         #end
     #end
-##    
+##
     #if ($widgetType == 'Department Contact Info')
         #if ($widget.getChild('contact').getChild('display-contact').value == 'Yes')
             #set($wHeading = 2)

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col.vtl
@@ -50,7 +50,7 @@
     ## News Tab Content
     <li>
       <div class="news-events-widget news clearfix">
-        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading events list..."/>
+        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading news list in left column..."/>
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)
@@ -63,7 +63,7 @@
     ## Events Tab Content
     <li>
       <div class="news-events-widget events clearfix">
-        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading events list..."/>
+        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading events list in left column..."/>
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Left_Col.vtl
@@ -33,7 +33,7 @@
     ## Featured Tab Content
     <li class="active">
       <div class="featured">
-        <img src="" alt="Chapman University" class="image" height="130"  width="225" />
+        <img src="/_files/1x1placeholder.jpg" alt="Chapman University feature story" class="image" height="130"  width="225" />
         <div class="date">
           <div class="day"></div>
           <div class="month"></div>

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
@@ -24,7 +24,7 @@
   #end
 
   #macro( buildContentList )
-    <ul class=".news-events-widget newsEventsContent">
+    <ul class="newsEventsContent">
       ## FIXME: This should be wrapped in a no-display li tag. But doing so will break
       ## tab functionality.
       <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
@@ -40,7 +40,7 @@
     <li class="active">
       <div class="featured">
         <div class="col1">
-          <img class="image" height="190" src="" width="190" alt="Chapman University"/>
+          <img src="/_files/1x1placeholder.jpg" alt="Chapman University featured story" class="image" height="190" width="190"/>
         </div>
         <div class="col2">
           <div class="date">
@@ -59,7 +59,7 @@
   #macro( buildNewsTabContent )
     <li>
       <div class="news clearfix">
-        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading news list for primary content..." />
+        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading news list for primary content..." />
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)
@@ -73,7 +73,7 @@
   #macro( buildEventsTabContent )
     <li>
       <div class="news-events-widget events clearfix">
-        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading events list for primary content..."/>
+        <img class="loading" src="/_files/level/img/ajax-loader.gif" alt="Loading events list for primary content..."/>
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)

--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Featured_News_Events_Primary_Content.vtl
@@ -24,7 +24,7 @@
   #end
 
   #macro( buildContentList )
-    <ul class="news-events-widget newsEventsContent">
+    <ul class=".news-events-widget newsEventsContent">
       ## FIXME: This should be wrapped in a no-display li tag. But doing so will break
       ## tab functionality.
       <a class="no-js-link" href="https://news.chapman.edu" title="View All News Stories">View All News »</a>
@@ -59,13 +59,13 @@
   #macro( buildNewsTabContent )
     <li>
       <div class="news clearfix">
-        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading news list..." />
+        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading news list for primary content..." />
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)
         #end
 
-        <a class="allNews" href="#">View all News »</a>
+        <a class="allNews" href="#">View more news »</a>
       </div>
     </li>
   #end
@@ -73,13 +73,13 @@
   #macro( buildEventsTabContent )
     <li>
       <div class="news-events-widget events clearfix">
-        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading events list..."/>
+        <img class="loading" src="../_files/level/img/ajax-loader.gif" alt="Loading events list for primary content..."/>
 
         #foreach ( $i in [1..3] )
           #buildStoryBlock($i)
         #end
 
-        <a class="allEvents" href="#">View all Events »</a>
+        <a class="allEvents" href="#">View more events »</a>
       </div>
     </li>
   #end

--- a/app/data_definitions/from_cascade/three_column.xml
+++ b/app/data_definitions/from_cascade/three_column.xml
@@ -147,7 +147,7 @@
         <dropdown-item show-fields="primaryContent/widget/twitterTimeline" value="Twitter Feed"/>
         <dropdown-item show-fields="primaryContent/widget/Calendar25Live" value="Calendar25Live"/>
         <dropdown-item show-fields="primaryContent/widget/AtoZListing" value="A to Z Listing"/>
-				<dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
+        <dropdown-item show-fields="primaryContent/widget/html-block" value="Html Block"/>
         <!--<dropdown-item show-fields="primaryContent/widget/reserved-block-formats" value="Reserved Block-Formats"/>-->
         <dropdown-item show-fields="primaryContent/widget/contact" value="Department Contact Info"/>
         <dropdown-item show-fields="primaryContent/widget/degree" value="Degree Info"/>
@@ -358,7 +358,8 @@
           <text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
         </group>
       </group>
-      <!--<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+      <!--
+      <group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
         <text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>
           <radio-item value="No"/>
@@ -400,23 +401,23 @@
         </group>
       </group>
       <group collapsed="true" identifier="form-embed" label="Form Embed">
-    <text default="Yes" identifier="display-form-embed" label="Show" required="true" type="radiobutton">
-      <radio-item value="Yes"/>
-      <radio-item value="No"/>
-    </text>
-    <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
-      <radio-item label="Cascade Block" show-fields="primaryContent/widget/form-embed/cascade-block" value="Cascade Block"/>
-      <radio-item label="External Javascript Embed or iFrame Block" show-fields="primaryContent/widget/form-embed/external-block" value="External Block"/>
-    </text>
-    <group identifier="cascade-block" label="Cascade Block">
-      <text identifier="header" label="Header"/>
-      <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
-      <asset help-text="link to _cascade/blocks/html/Forms-primary-content" identifier="code-block" label="Form Block" render-content-depth="unlimited" type="block"/>
-    </group>
-    <group identifier="external-block" label="External Block">
-      <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
-      <text help-text="paste in Javascript block provided by Embed Form action or iFrame in Formstack (check checkboxes for Don't Need Jquery or Jquery UI or Modernizer)" identifier="code-block" label="Embed or IFrame Code Block" multi-line="true" required="true"/>
-    </group>
+        <text default="Yes" identifier="display-form-embed" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+          <radio-item label="Cascade Block" show-fields="primaryContent/widget/form-embed/cascade-block" value="Cascade Block"/>
+          <radio-item label="External Javascript Embed or iFrame Block" show-fields="primaryContent/widget/form-embed/external-block" value="External Block"/>
+        </text>
+        <group identifier="cascade-block" label="Cascade Block">
+          <text identifier="header" label="Header"/>
+          <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
+          <asset help-text="link to _cascade/blocks/html/Forms-primary-content" identifier="code-block" label="Form Block" render-content-depth="unlimited" type="block"/>
+        </group>
+        <group identifier="external-block" label="External Block">
+          <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
+          <text help-text="paste in Javascript block provided by Embed Form action or iFrame in Formstack (check checkboxes for Don't Need Jquery or Jquery UI or Modernizer)" identifier="code-block" label="Embed or IFrame Code Block" multi-line="true" required="true"/>
+        </group>
       </group>
       <group collapsed="true" identifier="form" label="Form">
         <text default="Yes" identifier="display-form" label="Show" required="true" type="radiobutton">
@@ -768,6 +769,7 @@
       <asset identifier="feature" label="Feature" type="page"/>
       <text default="Default" help-text="Default is stories from Newsroom maintained by Marketing Dept at Chapman" identifier="newsFeed" label="News Feed" type="dropdown">
         <dropdown-item value="Default"/>
+        <dropdown-item value="Academics"/>
         <dropdown-item value="Admissions"/>
         <dropdown-item value="ASBE"/>
         <dropdown-item value="Commencement"/>

--- a/app/data_definitions/from_cascade/two_column.xml
+++ b/app/data_definitions/from_cascade/two_column.xml
@@ -392,7 +392,8 @@
           <text help-text="paste in raw html or Javascript link to render code or iFrame" identifier="code-block" label="HTml of Javascript Embed or IFrame Code Block" multi-line="true" required="true"/>
         </group>
       </group>
-      <!--<group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
+      <!--
+      <group collapsed="true" identifier="reserved-block-formats" label="Reserved Block/Formats">
         <text default="Yes" identifier="display-reserved-block-formats" label="Show" required="true" type="radiobutton">
           <radio-item value="Yes"/>
           <radio-item value="No"/>
@@ -434,23 +435,23 @@
         </group>
       </group>
       <group collapsed="true" identifier="form-embed" label="Form Embed">
-    <text default="Yes" identifier="display-form-embed" label="Show" required="true" type="radiobutton">
-      <radio-item value="Yes"/>
-      <radio-item value="No"/>
-    </text>
-    <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
-      <radio-item label="Cascade Block" show-fields="primaryContent/widget/form-embed/cascade-block" value="Cascade Block"/>
-      <radio-item label="External Javascript Embed or iFrame Block" show-fields="primaryContent/widget/form-embed/external-block" value="External Block"/>
-    </text>
-    <group identifier="cascade-block" label="Cascade Block">
-      <text identifier="header" label="Header"/>
-      <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
-      <asset help-text="link to _cascade/blocks/html/Forms-primary-content" identifier="code-block" label="Form Block" render-content-depth="unlimited" type="block"/>
-    </group>
-    <group identifier="external-block" label="External Block">
-      <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
-      <text help-text="paste in Javascript block provided by Embed Form action or iFrame in Formstack (check checkboxes for Don't Need Jquery or Jquery UI or Modernizer)" identifier="code-block" label="Embed or IFrame Code Block" multi-line="true" required="true"/>
-    </group>
+        <text default="Yes" identifier="display-form-embed" label="Show" required="true" type="radiobutton">
+          <radio-item value="Yes"/>
+          <radio-item value="No"/>
+        </text>
+        <text default="Cascade Block" identifier="block-type" label="Block Type" required="true" type="radiobutton">
+          <radio-item label="Cascade Block" show-fields="primaryContent/widget/form-embed/cascade-block" value="Cascade Block"/>
+          <radio-item label="External Javascript Embed or iFrame Block" show-fields="primaryContent/widget/form-embed/external-block" value="External Block"/>
+        </text>
+        <group identifier="cascade-block" label="Cascade Block">
+          <text identifier="header" label="Header"/>
+          <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
+          <asset help-text="link to _cascade/blocks/html/Forms-primary-content" identifier="code-block" label="Form Block" render-content-depth="unlimited" type="block"/>
+        </group>
+        <group identifier="external-block" label="External Block">
+          <text identifier="copy" label="Introductory Copy" wysiwyg="true"/>
+          <text help-text="paste in Javascript block provided by Embed Form action or iFrame in Formstack (check checkboxes for Don't Need Jquery or Jquery UI or Modernizer)" identifier="code-block" label="Embed or IFrame Code Block" multi-line="true" required="true"/>
+        </group>
       </group>
       <group collapsed="true" identifier="form" label="Form">
         <text default="Yes" identifier="display-form" label="Show" required="true" type="radiobutton">
@@ -688,6 +689,7 @@
       <asset identifier="feature" label="Feature" type="page"/>
       <text default="Default" help-text="Default is stories from Newsroom maintained by Marketing Dept at Chapman" identifier="newsFeed" label="News Feed" type="dropdown">
         <dropdown-item value="Default"/>
+        <dropdown-item value="Academics"/>
         <dropdown-item value="Admissions"/>
         <dropdown-item value="ASBE"/>
         <dropdown-item value="Commencement"/>


### PR DESCRIPTION
Some minor changes to the news/events widget for accessibility eg different text in the various View All links so different from each other; a placeholder image for Feature instead of empty src="". Also prevent the html for the widget from being placed on the page if user selected the widget but then elected Do Not Show as the dropdown option. That will prevent placeholder and empty html for things that aren't used anyway but flagged as issues with SiteImprove. Also add Academics as news widget feed option for Academic Technology blog.