### PR TITLE
ie 11 was broken with the previous js (checking for CSS grid support)

### DIFF
--- a/app/assets/javascripts/widgets/upgrade_alert.js
+++ b/app/assets/javascripts/widgets/upgrade_alert.js
@@ -1,5 +1,4 @@
-if ((navigator.appVersion.indexOf("MSIE ") !== -1) || !(CSS.supports("display: grid"))) {
-  // $('.noscript').css('display', 'block');
+
   var $buoop = {
     required: {
       i: 11,
@@ -10,28 +9,16 @@ if ((navigator.appVersion.indexOf("MSIE ") !== -1) || !(CSS.supports("display: g
       c: 57
     },
     insecure: true,
-    test: false,
-    api: 2019.10,
-    url: "https://www.chapman.edu/upgrade-browser.aspx",
+    api: 2019.10
   };
 
-  function $buo_f() {
-    var e = document.createElement("script");
-    e.src = "//browser-update.org/update.min.js";
-    document.body.appendChild(e);
-  };
-  try {
-    document.addEventListener("DOMContentLoaded", $buo_f, false)
-  } catch (e) {
-    window.attachEvent("onload", $buo_f)
-  }
-}
-
-
-
-
-
-
-var isIE10OrBelow = function () {
-  return /MSIE\s/.test(navigator.userAgent) && parseFloat(navigator.appVersion.split("MSIE")[1]) < 11;
+function $buo_f() {
+  var e = document.createElement("script");
+  e.src = "//browser-update.org/update.min.js";
+  document.body.appendChild(e);
+};
+try {
+  document.addEventListener("DOMContentLoaded", $buo_f, false)
+} catch (e) {
+  window.attachEvent("onload", $buo_f)
 }

--- a/app/assets/stylesheets/components/upgrade-alert.scss
+++ b/app/assets/stylesheets/components/upgrade-alert.scss
@@ -212,7 +212,7 @@ body {
 
     #buorg,
     #bourg>* {
-      display: none !important;
+      // display: none !important;
     }
   }
 }


### PR DESCRIPTION
This still checks for CSS Grid based on https://caniuse.com/#feat=css-grid and https://www.chapman.edu/upgrade-browser.aspx. Just removes extra conditional Javascript that I'd added to only run if the browser didn't support grid. 

      i: 11,
      e: 15,
      f: 52,
      o: 44,
      s: 10.1,
      c: 57