### PR TITLE
increase .logo-container specificity

### DIFF
--- a/app/assets/stylesheets/omni_nav/omni_nav_v2/off-canvas-nav.scss
+++ b/app/assets/stylesheets/omni_nav/omni_nav_v2/off-canvas-nav.scss
@@ -3,13 +3,17 @@
 ----------------------------------------------*/
 
 #omni-nav-v2 {
+  .cu-logo-wrapper {
+    max-width: 300px;
+  }
+
   .close {
     cursor: pointer;
     position: absolute;
     top: 0px;
     right: 0px;
     padding: 20px;
-    
+
     &:focus {
       outline: 2px dotted $cu-red;
       outline-offset: -2px;
@@ -84,9 +88,9 @@
         width: 100%;
         position: relative;
         display: flex;
-        max-width: 300px;
+        max-width: 100%;
         align-items: center;
-        
+
         div.toggle-logo {
           float: left;
           width: 50%;
@@ -119,8 +123,8 @@
       position: relative;
       left: 0;
       @include transition(all,
-      0.375s,
-      ease-in-out);
+        0.375s,
+        ease-in-out);
 
       li {
         list-style: none;
@@ -129,8 +133,8 @@
       a {
         left: 0;
         @include transition(all,
-        0.175s,
-        ease-in-out);
+          0.175s,
+          ease-in-out);
 
         &:hover {
           left: 5px;
@@ -212,7 +216,7 @@
 
               .toggle>span {
                 @include vendorize(transform,
-                rotate(45deg));
+                  rotate(45deg));
               }
             }
 
@@ -231,8 +235,8 @@
               position: relative;
               display: block;
               @include transition(all,
-              0.175s,
-              ease-in-out);
+                0.175s,
+                ease-in-out);
               vertical-align: middle;
               font-size: 16px;
 
@@ -256,8 +260,8 @@
                 display: block;
                 font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 @include transition(all,
-                0.175s,
-                ease-in-out);
+                  0.175s,
+                  ease-in-out);
 
                 svg {
                   width: 13px;
@@ -320,7 +324,7 @@
 
               .toggle>span {
                 @include vendorize(transform,
-                rotate(45deg));
+                  rotate(45deg));
               }
             }
 
@@ -335,8 +339,8 @@
               position: relative;
               display: block;
               @include transition(all,
-              0.175s,
-              ease-in-out);
+                0.175s,
+                ease-in-out);
               vertical-align: middle;
               font-size: 16px;
 
@@ -344,8 +348,8 @@
               svg {
                 position: relative;
                 @include transition(all,
-                0.175s,
-                ease-in-out);
+                  0.175s,
+                  ease-in-out);
               }
 
               &:before {
@@ -374,8 +378,8 @@
                 display: block;
                 font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 @include transition(all,
-                0.175s,
-                ease-in-out);
+                  0.175s,
+                  ease-in-out);
 
                 svg {
                   width: 13px;


### PR DESCRIPTION
I noticed an issue with the Omninav Breakpoint fix (https://github.com/chapmanu/cascade-assets/pull/555) where the off-canvas logo was tiny as a side effect:
https://dev-cascade.chapman.edu/entity/open.act?id=b6c55838c0a81e4b01e4ac41bb0f9bf7&type=page

This increases specificity to resolve the issue:
https://dev-cascade.chapman.edu/entity/open.act?id=23ff703ac0a81e4b53bc07db5269cb12&type=page

There is a hotfix on production