### PR TITLE
remove link to Graduate Research in omniNav

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/omni_nav_v2.vtl
@@ -711,7 +711,6 @@
           <li><a href="site://Chapman.edu/research/integrity/index">Research Integrity</a></li>
           <li><a href="site://Chapman.edu/research/institutes-and-centers/index">Institutes &amp; Centers</a></li>
           <li><a href="site://Chapman.edu/research/center-for-undergraduate-excellence/index">Center for Undergraduate Excellence</a></li>
-          <li><a href="site://Chapman.edu/research/graduate-research/index">Graduate Research Support</a></li>
         </ul>
       </li>
       <li>

--- a/.cascade-code/Chapman.edu/_config/global_nav.vm
+++ b/.cascade-code/Chapman.edu/_config/global_nav.vm
@@ -206,11 +206,6 @@
         'text': 'Center for Undergraduate Excellence',
         'link': '/research/center-for-undergraduate-excellence/index',
         'iconClass': 'icon-lamp8'
-      },
-      {
-        'text': 'Graduate Research Support',
-        'link': '/research/graduate-research/index',
-        'iconClass': 'icon-microscope'
       }
     ]
   },

--- a/app/views/widgets/shared/_header.html
+++ b/app/views/widgets/shared/_header.html
@@ -449,11 +449,6 @@
                           Center for Undergraduate Excellence
                         </a>
                       </li>
-                      <li>
-                        <a class="icon icon-microscope" href="research/graduate-research/index.aspx">
-                          Graduate Research Support
-                        </a>
-                      </li>
                     </ul>
                   </div>
                 </li>
@@ -783,7 +778,6 @@
                 <li><a href="research/institutes-and-centers/index.aspx">Institutes &amp; Centers</a></li>
                 <li><a href="research/office-undergraduate-research-creative-activity/index.aspx">Center for
                     Undergraduate Excellence</a></li>
-                <li><a href="research/graduate-research/index.aspx">Graduate Research Support</a></li>
               </ul>
             </li>
             <li>


### PR DESCRIPTION
remove link that's currently in omniNav and hamburger's Main Menu in the Research section. It's the Graduate Research link. Per SMC that site is being retired.