### PR TITLE
add opacity and delay to noscript upgrade alert

### DIFF
--- a/app/assets/stylesheets/components/upgrade-alert.scss
+++ b/app/assets/stylesheets/components/upgrade-alert.scss
@@ -107,8 +107,8 @@ body {
       z-index: 9;
       display: block !important;
       opacity: 0;
-      -webkit-animation: fadeIn 3s linear forwards;
-      animation: fadeIn 3s linear forwards;
+      -webkit-animation: fadeIn 1s linear forwards;
+      animation: fadeIn 1s linear forwards;
       animation-delay: 3s;
     }
 

--- a/app/assets/stylesheets/components/upgrade-alert.scss
+++ b/app/assets/stylesheets/components/upgrade-alert.scss
@@ -98,7 +98,7 @@ body {
     display: none;
   }
 
-   .noscript {
+  .noscript {
     #buorg {
       top: 0;
       margin-top: $omniNavHeightMobile;
@@ -106,43 +106,82 @@ body {
       width: 100%;
       z-index: 9;
       display: block !important;
+      opacity: 0;
+      -webkit-animation: fadeIn 3s linear forwards;
+      animation: fadeIn 3s linear forwards;
+      animation-delay: 3s;
     }
 
     .buorg-pad {
       display: block;
       text-align: center;
     }
+
+    @-webkit-keyframes fadeIn {
+      from {
+        opacity: 0
+      }
+
+      to {
+        opacity: 1
+      }
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0
+      }
+
+      to {
+        opacity: 1
+      }
+    }
+
+    @keyframes fadeinout {
+
+      0%,
+      100% {
+        opacity: 0;
+      }
+
+      50% {
+        opacity: 1;
+      }
+    }
   }
-// IE 6-8
-@media \0screen\,screen\9 {
-  .noscript {
+
+  // IE 6-8
+  @media \0screen\,screen\9 {
+    .noscript {
+      #buorg {
+        top: 0;
+        margin-top: $omniNavHeightMobile;
+        position: absolute;
+        width: 100%;
+        z-index: 9;
+      }
+
+      .buorg-pad {
+        display: block;
+        text-align: center;
+      }
+    }
+
     #buorg {
-      top: 0;
-      margin-top: $omniNavHeightMobile;
-      position: absolute;
-      width: 100%;
-      z-index: 9;
+      top: 0 !important;
+      margin-top: 60px !important;
+      position: absolute !important;
+      width: 100% !important;
+      z-index: 9 !important;
+      display: block !important;
     }
 
     .buorg-pad {
-      display: block;
-      text-align: center;
+      display: block !important;
+      text-align: center !important;
     }
   }
-  #buorg {
-    top: 0 !important;
-    margin-top: 60px !important;
-    position: absolute !important;
-    width: 100%  !important;
-    z-index: 9  !important;
-    display: block !important;
-  }
 
-  .buorg-pad {
-    display: block !important;
-    text-align: center !important;
-  }
-}
   // IE 9
   #omni-nav-v2 {
     // display: none \9;
@@ -163,7 +202,7 @@ body {
   }
 
   @media screen and (min-width:0) and (min-resolution:.001dpcm) {
-     .noscript {
+    .noscript {
       #buorg {
         top: 0;
         margin-top: $omniNavHeightMobile;
@@ -205,7 +244,6 @@ body {
     }
   }
 }
-
 
 @supports (display: grid) {
   body {


### PR DESCRIPTION
The browser upgrade alert has a `<noscript>` fallback. I noticed it flashes briefly (on a page with working JavaScript) if the page isn't cached. This uses a CSS keyframe to apply a delayed fadeIn when JS is disabled/broken/hasn't loaded yet

https://dev-www.chapman.edu/test-section/nick-test/browser-upgrade-noscript-opacity.aspx (try with JS disabled)
 