### PR TITLE
Add heading field to CTA 3-upwidget  in 1 Column  Modular

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/call_to_action_3_up.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/one_column/call_to_action_3_up.vtl
@@ -9,9 +9,13 @@
     #if ($displayCallToAction3Up == 'Yes')
         #set ($callToAction3Up = $element.getChild('callToAction3Up'))
         #set ($classStr = "call-to-action-3-up-widget")
+        #set ($sectionHeading = $callToAction3Up.getChild('heading').value)
 
         <div class="${classStr} #outputBgColorClass($callToAction3Up $classStr)">
             <div class="outer-container">
+                #if ($sectionHeading != '')
+                    <h2 class="section-heading">$_EscapeTool.xml($sectionHeading)</h2>
+                #end
                 #outputCtaColumn($callToAction3Up.getChild('cta1'))
                 #outputCtaColumn($callToAction3Up.getChild('cta2'))
                 #outputCtaColumn($callToAction3Up.getChild('cta3'))
@@ -33,7 +37,11 @@
             <img class="image" #outputSrc($media) alt="$alternateText"/>
         </div>
         <div class="text-wrap">
-            <h2 class="headline">$title</h2>
+            #if ($sectionHeading != '')
+                <h3 class="headline">$title</h3>
+            #else
+                <h2 class="headline">$title</h2>
+            #end
             <p class="text-content">$body</p>
             <a #outputHref($link) class="more-link"><span class="underline">$label</span></a>
         </div>

--- a/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
+++ b/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
@@ -10,8 +10,9 @@
     -ms-flex-preferred-size: 100%;
     flex-basis: 100%;
     width: 100%;
-    margin-bottom: 1em;
-    font-size: 2em;
+    margin: 0;
+    padding: 0 1em 1.2em 1em;
+    font-size: 2.2em;
     line-height: 1em;
     text-align: center;
   }

--- a/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
+++ b/app/assets/stylesheets/widgets/single_column/call_to_action_3_up.scss
@@ -6,6 +6,16 @@
     @include outer-container();
   }
 
+  .section-heading {
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+    width: 100%;
+    margin-bottom: 1em;
+    font-size: 2em;
+    line-height: 1em;
+    text-align: center;
+  }
+    
   .column {
     margin-bottom: $base-spacing*3;
 

--- a/app/data_definitions/from_cascade/one_column.xml
+++ b/app/data_definitions/from_cascade/one_column.xml
@@ -693,6 +693,7 @@
 					<radio-item value="Yes"/>
 					<radio-item value="No"/>
 				</text>
+				<text help-text="Section Heading above all 3 photos" identifier="heading" label="Heading" required="false"/>
 				<text default="Light" identifier="bgColor" label="Background Color" type="radiobutton">
 					<radio-item value="Light"/>
 					<radio-item value="Medium"/>

--- a/app/views/1_column/hero_side_panel.html.erb
+++ b/app/views/1_column/hero_side_panel.html.erb
@@ -5,8 +5,9 @@
   primary_content:
     - hero/side_panel
     - single_column/call_to_action_block
-    - single_column/chapman_events_feed
     - single_column/messaging_1_column_facts
+    - single_column/chapman_events_feed
+    - single_column/call_to_action_3_up
     - single_column/messaging_2_column_youtube_video
     - single_column/messaging_2_column_vimeo_video
 

--- a/app/views/widgets/single_column/_call_to_action_3_up.html
+++ b/app/views/widgets/single_column/_call_to_action_3_up.html
@@ -1,5 +1,6 @@
 <div class="call-to-action-3-up-widget">
 	<div class= "outer-container">
+    <h2 class="section-heading">Call To Action 3-up Widget Heading</h2>
 		<div class="column">
 			<div class= "image-wrap">
 				<a href= ""><img class= "image" src="http://static.tumblr.com/vlykcdf/lN2l9mwte/cute-kitten-303.jpg" /></a>
@@ -7,7 +8,7 @@
 			<div class= "text-wrap">
 				<h2 class="headline">Sample CTA Column</h2>
 				<p class="text-content">
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet libero ultrices, aliquam ligula eu, sodales ligula. Ut maximus mauris tincidunt maximus hendrerit. Nullam velit felis, ultricies sit amet efficitur at, aliquet vitae velit.
+					LOREM ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sit amet libero ultrices, aliquam ligula eu, sodales ligula. Ut maximus mauris tincidunt maximus hendrerit. Nullam velit felis, ultricies sit amet efficitur at, aliquet vitae velit.
 				</p>
 				<a class="more-link"><span class="underline">This link text is a little longer than expected. Underline should wrap...</span></a>
 			</div>
@@ -26,7 +27,7 @@
 		</div>
 		<div class="column">
 			<div class= "image-wrap">
-				<a href= ""><img class= "image" src="http://www.wallpapersfordesktop.org/wp-content/uploads/2015/10/cute-kittens30.jpg" /></a>
+				<a href= ""><img class= "image" src="http://static.tumblr.com/vlykcdf/lN2l9mwte/cute-kitten-303.jpg" /></a>
 			</div>
 			<div class= "text-wrap">
 				<h2 class="headline">Sample CTA Column</h2>


### PR DESCRIPTION
A small change to 1 Col to add a section heading field similar to other widgets, this for the Call To Action 3 Up widget. Ross got request from Law School. Sample shown on https://dev-www.chapman.edu/law/index-test2.aspx