### PR TITLE
fix width to 100% for landscape photos

### DIFF
--- a/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Photo Callout.vtl
+++ b/.cascade-code/Chapman.edu/_cascade/formats/modular/widgets/Photo Callout.vtl
@@ -33,6 +33,7 @@
 #if ($aspectRatio == "Horizontal 'Landscape' Images (4:3 Aspect Ratio)")
     #set ($aspectRatio = 'photo-callout-widget__container--landscape' )
     #set ($textPosition = '' )
+    #set ($imageWidth = '100%')
 #else 
     #set ($aspectRatio = 'photo-callout-widget__container--headshot' )
 #end


### PR DESCRIPTION
Looks like Photo Callout Widget 'landscape' width was cut short by some inline styles from helpers.velocity
Setting the imageWidth inside the PhotoCallout.vtl to 100% fixes the issue across all pages that use this widget.